### PR TITLE
Allow single node testnet

### DIFF
--- a/preset/config.go
+++ b/preset/config.go
@@ -28,7 +28,7 @@ var (
 	}
 
 	TestnetPresetConfig = &PresetConfig{
-		CommitteeMinSize: 3,
+		CommitteeMinSize: 1,
 		CommitteeMaxSize: 300,
 		DelegateMaxSize:  500,
 		DiscoServer:      "enode://20cd29b988266dfee6a2afc25086aaf5b2019f44d0845bac9beebe13ee3752bf2380f932fe9c153497d36d866fe591fa246c0baf817547ecc3ebe6014f895792@34.31.117.124:55555",


### PR DESCRIPTION
## Summary
- Reduce testnet `CommitteeMinSize` from 3 to 1, enabling single-node testnet operation
- `MajorityTwoThird(1, 1)` already returns `true` (`ceil(1 * 2/3) = 1`), so no consensus code changes needed
- All other code paths (leader election, QC construction, reward distribution, message relay) handle committee size of 1 correctly

## Test plan
- [ ] Start a single-node testnet and verify it produces blocks
- [ ] Verify consensus rounds advance without hanging
- [ ] Confirm transactions can be submitted and executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)