### PR TITLE
Remove PoW dependency, derive epoch nonce from kblock hash

### DIFF
--- a/consensus/pacemaker.go
+++ b/consensus/pacemaker.go
@@ -6,6 +6,7 @@
 package consensus
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -18,7 +19,6 @@ import (
 	"github.com/meterio/meter-pov/chain"
 	"github.com/meterio/meter-pov/meter"
 	"github.com/meterio/meter-pov/packer"
-	"github.com/meterio/meter-pov/powpool"
 	"github.com/meterio/meter-pov/types"
 )
 
@@ -129,16 +129,15 @@ func (p *Pacemaker) CreateLeaf(parent *block.DraftBlock, justify *block.DraftQC,
 	}
 
 	proposeKBlock := false
-	var powResults *powpool.PowResult
 	if !parentBlock.IsKBlock() && (parentBlock.Number()+1-parentBlock.LastKBlockHeight()) >= p.minMBlocks && !timeout {
-		proposeKBlock, powResults = powpool.GetGlobPowPoolInst().GetPowDecision()
+		proposeKBlock = true
 	}
 	// propose appropriate block info
 	if proposeKBlock {
-		kblockData := &block.KBlockData{Nonce: uint64(powResults.Nonce), Data: powResults.Raw}
-		rewards := powResults.Rewards
+		nonce := binary.BigEndian.Uint64(parentBlock.ID().Bytes()[:8])
+		kblockData := &block.KBlockData{Nonce: nonce, Data: []block.PowRawBlock{}}
 		p.logger.Info(fmt.Sprintf("proposing KBlock on R:%v with QCHigh(#%v,R:%v), Parent(%v,R:%v)", round, justify.QC.QCHeight, justify.QC.QCRound, parent.ProposedBlock.ID().ToBlockShortID(), parent.Round))
-		return p.buildKBlock(uint64(targetTime.Unix()), parent, justify, round, kblockData, rewards)
+		return p.buildKBlock(uint64(targetTime.Unix()), parent, justify, round, kblockData)
 	} else {
 		if !parent.ProposedBlock.IsKBlock() { // only check round if parent is not KBlock
 			if p.reactor.curEpoch != 0 && round != 0 && round <= justify.QC.QCRound {

--- a/consensus/pacemaker_propose.go
+++ b/consensus/pacemaker_propose.go
@@ -14,7 +14,6 @@ import (
 	"github.com/meterio/meter-pov/block"
 	"github.com/meterio/meter-pov/meter"
 	"github.com/meterio/meter-pov/packer"
-	"github.com/meterio/meter-pov/powpool"
 	"github.com/meterio/meter-pov/runtime"
 	"github.com/meterio/meter-pov/tx"
 )
@@ -280,7 +279,7 @@ func (p *Pacemaker) packMBlock() error {
 	return nil
 }
 
-func (p *Pacemaker) buildKBlock(ts uint64, parent *block.DraftBlock, justify *block.DraftQC, round uint32, kblockData *block.KBlockData, rewards []powpool.PowReward) (error, *block.DraftBlock) {
+func (p *Pacemaker) buildKBlock(ts uint64, parent *block.DraftBlock, justify *block.DraftQC, round uint32, kblockData *block.KBlockData) (error, *block.DraftBlock) {
 	parentBlock := parent.ProposedBlock
 	qc := justify.QC
 	best := parentBlock
@@ -297,7 +296,7 @@ func (p *Pacemaker) buildKBlock(ts uint64, parent *block.DraftBlock, justify *bl
 		return errors.New("state creater not ready"), nil
 	}
 
-	txs := p.reactor.buildKBlockTxs(parentBlock, rewards, chainTag, bestNum, curEpoch, best, state)
+	txs := p.reactor.buildKBlockTxs(parentBlock, chainTag, bestNum, curEpoch, best, state)
 
 	pker := p.reactor.packer
 	if pker == nil {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -13,7 +13,6 @@ import (
 	"encoding/base64"
 	b64 "encoding/base64"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +38,6 @@ import (
 	"github.com/meterio/meter-pov/logdb"
 	"github.com/meterio/meter-pov/meter"
 	"github.com/meterio/meter-pov/packer"
-	"github.com/meterio/meter-pov/powpool"
 	"github.com/meterio/meter-pov/state"
 	"github.com/meterio/meter-pov/txpool"
 	"github.com/meterio/meter-pov/types"
@@ -338,25 +336,6 @@ func (r *Reactor) PrepareEnvForPacemaker() error {
 	}
 	r.logger.Info("prepare env for pacemaker", "nonce", r.curNonce, "bestK", bestKBlock.Number(), "bestIsKBlock", bestIsKBlock, "epoch", r.curEpoch)
 
-	var info *powpool.PowBlockInfo
-	if bestKBlock.Number() == 0 {
-		info = powpool.GetPowGenesisBlockInfo()
-	} else {
-		info = powpool.NewPowBlockInfoFromPosKBlock(bestKBlock)
-	}
-	r.logger.Info("Powpool prepare to add kframe, and notify PoW chain to pick head", "powHeight", info.PowHeight, "powRawBlock", hex.EncodeToString(info.PowRaw))
-	pool := powpool.GetGlobPowPoolInst()
-	// pool.Wash()
-	pool.InitialAddKframe(info)
-	r.logger.Info("Powpool initial added kframe", "bestK", bestKBlock.Number(), "powHeight", info.PowHeight)
-	if r.inCommittee {
-		//kblock is already added to pool, should start with next one
-		// startHeight := info.PowHeight + 1
-		// r.logger.Info("Replay pow blocks", "fromHeight", startHeight)
-		// pool.ReplayFrom(int32(startHeight))
-		pool.WaitForSync()
-	}
-
 	return nil
 }
 
@@ -488,7 +467,7 @@ func (r *Reactor) UpdateCurEpoch() (bool, error) {
 	if bestK.Number() == 0 {
 		nonce = genesis.GenesisNonce
 	} else {
-		nonce = bestK.KBlockData.Nonce
+		nonce = binary.BigEndian.Uint64(bestK.ID().Bytes()[:8])
 		epoch = bestK.GetBlockEpoch() + 1
 	}
 	if epoch >= r.curEpoch && r.curNonce != nonce {
@@ -524,7 +503,7 @@ func (r *Reactor) UpdateCurEpoch() (bool, error) {
 				if err != nil {
 					r.logger.Error("could not get trunk block", "err", err)
 				} else {
-					lastNonce = lastBestK.KBlockData.Nonce
+					lastNonce = binary.BigEndian.Uint64(lastBestK.ID().Bytes()[:8])
 				}
 			}
 

--- a/consensus/reactor_validate.go
+++ b/consensus/reactor_validate.go
@@ -22,7 +22,6 @@ import (
 	"github.com/meterio/meter-pov/block"
 	"github.com/meterio/meter-pov/consensus/governor"
 	"github.com/meterio/meter-pov/meter"
-	"github.com/meterio/meter-pov/powpool"
 	"github.com/meterio/meter-pov/runtime"
 	"github.com/meterio/meter-pov/script"
 	"github.com/meterio/meter-pov/state"
@@ -215,12 +214,10 @@ func (c *Reactor) validateBlockBody(blk *block.Block, parent *block.Block, force
 			return err
 		}
 
-		proposalKBlock, powResults := powpool.GetGlobPowPoolInst().GetPowDecision()
-		if proposalKBlock && forceValidate {
-			rewards := powResults.Rewards
+		if forceValidate {
 			start := time.Now()
 			c.logger.Info("< Begin locally build KBlock txs for validation ")
-			kblockTxs := c.buildKBlockTxs(parent, rewards, chainTag, bestNum, curEpoch, best, state)
+			kblockTxs := c.buildKBlockTxs(parent, chainTag, bestNum, curEpoch, best, state)
 			// for _, tx := range kblockTxs {
 			// 	fmt.Println("tx=", tx.ID(), ", uniteHash=", tx.UniteHash(), "gas", tx.Gas())
 			// }
@@ -486,17 +483,12 @@ func (c *Reactor) VerifyBlock(blk *block.Block, state *state.State, forceValidat
 }
 
 func (c *Reactor) verifyKBlock() error {
-	p := powpool.GetGlobPowPoolInst()
-	if !p.VerifyNPowBlockPerEpoch() {
-		return errors.New("NPowBlockPerEpoch err")
-	}
-
 	return nil
 }
 
-func (r *Reactor) buildKBlockTxs(parentBlock *block.Block, rewards []powpool.PowReward, chainTag byte, bestNum uint32, curEpoch uint32, best *block.Block, state *state.State) tx.Transactions {
+func (r *Reactor) buildKBlockTxs(parentBlock *block.Block, chainTag byte, bestNum uint32, curEpoch uint32, best *block.Block, state *state.State) tx.Transactions {
 	// build miner meter reward
-	txs := governor.BuildMinerRewardTxs(rewards, chainTag, bestNum)
+	txs := governor.BuildMinerRewardTxs(nil, chainTag, bestNum)
 	for _, tx := range txs {
 		r.logger.Info(fmt.Sprintf("Built miner reward tx: %s", tx.ID().String()), "clauses", len(tx.Clauses()), "uhash", tx.UniteHash())
 	}


### PR DESCRIPTION
## Summary

- **KBlock proposal**: instead of waiting on `powpool.GetPowDecision()`, a KBlock is now proposed as soon as `minMBlocks` have accumulated since the last KBlock. No external PoW chain needed.
- **Committee nonce**: the nonce used to shuffle the validator committee is now derived from the parent KBlock's block ID (`binary.BigEndian.Uint64(kblock.ID().Bytes()[:8])`) instead of `KBlockData.Nonce` from the PoW chain.
- **`PrepareEnvForPacemaker`**: removed the `powpool.InitialAddKframe` / `WaitForSync` calls that blocked startup on PoW sync.
- **`validateBlockBody`**: KBlock tx validation now always runs (was gated on `powpool.GetPowDecision()` returning true).
- **`verifyKBlock`**: removed the `VerifyNPowBlockPerEpoch` check.
- **Miner reward txs**: `BuildMinerRewardTxs` is called with `nil` rewards (no-op), so no miner reward transactions are emitted.

## Trade-off

The KBlock proposer can predict (and weakly influence) who leads the next epoch, since the nonce comes from their own block's hash. This is acceptable for a PoW-free testnet but is worth noting for production use.

## Test plan

- [ ] Start a local testnet with no Bitcoin node configured — nodes should form epochs and rotate committees normally
- [ ] Confirm KBlocks are produced every `minMBlocks` M-blocks
- [ ] Confirm committee is reshuffled each epoch (different proposer order)
- [ ] Confirm no startup hang waiting for PoW sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)