### PR TITLE
fix: remove powpool blocking calls and fix outgoing queue shutdown

### DIFF
--- a/consensus/outgoing_queue.go
+++ b/consensus/outgoing_queue.go
@@ -62,9 +62,6 @@ func (q *OutgoingQueue) Add(to ConsensusPeer, msg block.ConsensusMessage, rawMsg
 		default:
 		}
 	}
-	// Store context for shutdown checks in Add()
-	q.ctx = ctx
-	
 	
 	for len(q.queue) >= cap(q.queue) {
 		p := <-q.queue
@@ -84,6 +81,9 @@ func (q *OutgoingQueue) Add(to ConsensusPeer, msg block.ConsensusMessage, rawMsg
 func (q *OutgoingQueue) Start(ctx context.Context) {
 	q.logger.Info(`outgoing queue started`)
 
+	// Store context for shutdown checks in Add()
+	q.ctx = ctx
+	
 	for i := 1; i <= WORKER_CONCURRENCY; i++ {
 		worker := NewOutgoingWorker(i)
 		q.WaitGroup.Add(1)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -13,7 +13,6 @@ import (
 	"encoding/base64"
 	b64 "encoding/base64"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -39,7 +38,6 @@ import (
 	"github.com/meterio/meter-pov/logdb"
 	"github.com/meterio/meter-pov/meter"
 	"github.com/meterio/meter-pov/packer"
-	"github.com/meterio/meter-pov/powpool"
 	"github.com/meterio/meter-pov/state"
 	"github.com/meterio/meter-pov/txpool"
 	"github.com/meterio/meter-pov/types"
@@ -337,25 +335,6 @@ func (r *Reactor) PrepareEnvForPacemaker() error {
 		return err
 	}
 	r.logger.Info("prepare env for pacemaker", "nonce", r.curNonce, "bestK", bestKBlock.Number(), "bestIsKBlock", bestIsKBlock, "epoch", r.curEpoch)
-
-	var info *powpool.PowBlockInfo
-	if bestKBlock.Number() == 0 {
-		info = powpool.GetPowGenesisBlockInfo()
-	} else {
-		info = powpool.NewPowBlockInfoFromPosKBlock(bestKBlock)
-	}
-	r.logger.Info("Powpool prepare to add kframe, and notify PoW chain to pick head", "powHeight", info.PowHeight, "powRawBlock", hex.EncodeToString(info.PowRaw))
-	pool := powpool.GetGlobPowPoolInst()
-	// pool.Wash()
-	pool.InitialAddKframe(info)
-	r.logger.Info("Powpool initial added kframe", "bestK", bestKBlock.Number(), "powHeight", info.PowHeight)
-	if r.inCommittee {
-		//kblock is already added to pool, should start with next one
-		// startHeight := info.PowHeight + 1
-		// r.logger.Info("Replay pow blocks", "fromHeight", startHeight)
-		// pool.ReplayFrom(int32(startHeight))
-		pool.WaitForSync()
-	}
 
 	return nil
 }


### PR DESCRIPTION
- Remove powpool.WaitForSync() blocking call in PrepareEnvForPacemaker
- Remove powpool.InitialAddKframe() initialization code
- Remove unused powpool and hex imports from reactor.go
- Fixes node startup hang waiting for PoW chain sync
- Fix race condition in OutgoingQueue.Add() during shutdown
- Now nodes can start without PoW dependencies (testnet mode)

Aligns with PR #34 changes to remove PoW dependency