### PR TITLE
fix: shutdown panic + solo mode flag

### DIFF
--- a/api/node/node_test.go
+++ b/api/node/node_test.go
@@ -50,7 +50,7 @@ func initCommServer(t *testing.T) {
 		Limit:           10000,
 		LimitPerAccount: 16,
 		MaxLifetime:     10 * time.Minute,
-	}), nil, "main", [4]byte{1, 2, 3, 4})
+	}), nil, "main", [4]byte{1, 2, 3, 4}, false)
 	router := mux.NewRouter()
 	node.New(comm, nil, "pubkey").Mount(router, "/node")
 	ts = httptest.NewServer(router)

--- a/cmd/meter/flags.go
+++ b/cmd/meter/flags.go
@@ -131,6 +131,10 @@ var (
 		Name:  "no-discover",
 		Usage: "disable auto discovery mode",
 	}
+	soloFlag = cli.BoolFlag{
+		Name:  "solo",
+		Usage: "run in solo mode: no discovery, no peer sync, start consensus immediately",
+	}
 	minCommitteeSizeFlag = cli.IntFlag{
 		Name:  "committee-min-size",
 		Usage: "committee minimum size",

--- a/cmd/meter/main.go
+++ b/cmd/meter/main.go
@@ -127,6 +127,7 @@ func main() {
 			powUserFlag,
 			powPassFlag,
 			noDiscoverFlag,
+			soloFlag,
 			minCommitteeSizeFlag,
 			maxCommitteeSizeFlag,
 			maxDelegateSizeFlag,

--- a/cmd/meter/must.go
+++ b/cmd/meter/must.go
@@ -311,22 +311,33 @@ func newP2PComm(cliCtx *cli.Context, ctx context.Context, chain *chain.Chain, tx
 		os.Exit(1)
 	}
 
+	solo := cliCtx.Bool("solo")
+
 	// if the discoverServerFlag is not set, use default hardcoded nodes
 	var BootstrapNodes []*enode.Node
-	if overrided == true {
+	if solo {
+		BootstrapNodes = nil
+	} else if overrided == true {
 		BootstrapNodes = discoSvr
 	} else {
 		BootstrapNodes = bootstrapNodes
 	}
 
+	maxPeers := cliCtx.Int(maxPeersFlag.Name)
+	noDiscovery := cliCtx.Bool("no-discover")
+	if solo {
+		maxPeers = 0
+		noDiscovery = true
+	}
+
 	opts := &p2psrv.Options{
 		Name:           meter.MakeName("meter", fullVersion()),
 		PrivateKey:     key,
-		MaxPeers:       cliCtx.Int(maxPeersFlag.Name),
+		MaxPeers:       maxPeers,
 		ListenAddr:     fmt.Sprintf(":%v", cliCtx.Int(p2pPortFlag.Name)),
 		BootstrapNodes: BootstrapNodes,
 		NAT:            nat,
-		NoDiscovery:    cliCtx.Bool("no-discover"),
+		NoDiscovery:    noDiscovery,
 	}
 
 	peersCachePath := filepath.Join(instanceDir, "peers.cache")
@@ -365,7 +376,7 @@ func newP2PComm(cliCtx *cli.Context, ctx context.Context, chain *chain.Chain, tx
 	topic := cliCtx.String("disco-topic")
 
 	return &p2pComm{
-		comm:           comm.New(ctx, chain, txPool, powPool, topic, magic),
+		comm:           comm.New(ctx, chain, txPool, powPool, topic, magic, solo),
 		p2pSrv:         p2psrv.New(opts),
 		peersCachePath: peersCachePath,
 	}

--- a/comm/communicator.go
+++ b/comm/communicator.go
@@ -53,13 +53,14 @@ type Communicator struct {
 
 	powPool     *powpool.PowPool
 	configTopic string
+	solo        bool
 
 	magic  [4]byte
 	logger *slog.Logger
 }
 
 // New create a new Communicator instance.
-func New(ctx context.Context, chain *chain.Chain, txPool *txpool.TxPool, powPool *powpool.PowPool, configTopic string, magic [4]byte) *Communicator {
+func New(ctx context.Context, chain *chain.Chain, txPool *txpool.TxPool, powPool *powpool.PowPool, configTopic string, magic [4]byte, solo bool) *Communicator {
 	return &Communicator{
 		chain:   chain,
 		txPool:  txPool,
@@ -71,6 +72,7 @@ func New(ctx context.Context, chain *chain.Chain, txPool *txpool.TxPool, powPool
 		announcementCh: make(chan *announcement),
 		configTopic:    configTopic,
 		magic:          magic,
+		solo:           solo,
 		logger:         slog.With("pkg", "comm"),
 	}
 }
@@ -82,6 +84,12 @@ func (c *Communicator) Synced() <-chan struct{} {
 
 // Sync start synchronization process.
 func (c *Communicator) Sync(handler HandleBlockStream) {
+	if c.solo {
+		c.logger.Info("solo mode: skipping peer sync, marking as synced immediately")
+		c.onceSynced.Do(func() { close(c.syncedCh) })
+		return
+	}
+
 	const initSyncInterval = 500 * time.Millisecond
 	const syncInterval = 6 * time.Second
 

--- a/consensus/outgoing_queue.go
+++ b/consensus/outgoing_queue.go
@@ -37,6 +37,7 @@ type OutgoingQueue struct {
 	sync.WaitGroup
 	logger  *slog.Logger
 	queue   chan (OutgoingParcel)
+	done    chan struct{}
 	clients map[string]*http.Client
 }
 
@@ -44,6 +45,7 @@ func NewOutgoingQueue() *OutgoingQueue {
 	return &OutgoingQueue{
 		logger:  slog.With("pkg", "out"),
 		queue:   make(chan (OutgoingParcel), 2048),
+		done:    make(chan struct{}),
 		clients: make(map[string]*http.Client),
 	}
 }
@@ -51,10 +53,18 @@ func NewOutgoingQueue() *OutgoingQueue {
 func (q *OutgoingQueue) Add(to ConsensusPeer, msg block.ConsensusMessage, rawMsg []byte, relay bool) {
 	q.logger.Debug(fmt.Sprintf("add %s msg to out queue", msg.GetType()), "to", to, "len", len(q.queue), "cap", cap(q.queue))
 	for len(q.queue) >= cap(q.queue) {
-		p := <-q.queue
-		q.logger.Info(fmt.Sprintf(`%s msg dropped due to cap ...`, p.msgType))
+		select {
+		case <-q.done:
+			return
+		case p := <-q.queue:
+			q.logger.Info(fmt.Sprintf(`%s msg dropped due to cap ...`, p.msgType))
+		}
 	}
-	q.queue <- OutgoingParcel{to: to, msgType: msg.GetType(), msgSummary: msg.String(), rawMsg: rawMsg, relay: relay, enqueueAt: time.Now(), expireAt: time.Now().Add(OUT_QUEUE_TTL)}
+	select {
+	case <-q.done:
+		return
+	case q.queue <- OutgoingParcel{to: to, msgType: msg.GetType(), msgSummary: msg.String(), rawMsg: rawMsg, relay: relay, enqueueAt: time.Now(), expireAt: time.Now().Add(OUT_QUEUE_TTL)}:
+	}
 }
 
 func (q *OutgoingQueue) Start(ctx context.Context) {
@@ -66,6 +76,7 @@ func (q *OutgoingQueue) Start(ctx context.Context) {
 		go worker.Run(ctx, q.queue, &q.WaitGroup)
 	}
 	<-ctx.Done()
+	close(q.done)
 	close(q.queue)
 	q.WaitGroup.Wait()
 }

--- a/consensus/pacemaker.go
+++ b/consensus/pacemaker.go
@@ -827,6 +827,12 @@ func (p *Pacemaker) mainLoop() {
 			p.mainLoopStarted = false
 			return
 
+		case <-p.reactor.ctx.Done():
+			p.logger.Info("context done, stopping pacemaker main loop")
+			p.cancelAllPendingBroadcast()
+			p.mainLoopStarted = false
+			return
+
 		}
 	}
 }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -107,6 +107,8 @@ type Reactor struct {
 
 	inQueue  *IncomingQueue
 	outQueue *OutgoingQueue
+
+	ctx context.Context
 }
 
 // NewConsensusReactor returns a new Reactor with config
@@ -168,6 +170,7 @@ func NewConsensusReactor(ctx *cli.Context, chain *chain.Chain, logDB *logdb.LogD
 // OnStart implements BaseService by subscribing to events, which later will be
 // broadcasted to other peers and starting state if we're not in fast sync.
 func (r *Reactor) OnStart(ctx context.Context) error {
+	r.ctx = ctx
 
 	go r.outQueue.Start(ctx)
 


### PR DESCRIPTION
## Changes

### 1. Fix panic on shutdown: send to closed channel

During graceful shutdown (SIGTERM):
1. \`OutgoingQueue.Start\` detects \`ctx.Done()\` and calls \`close(q.queue)\`
2. \`Pacemaker.mainLoop\` had no \`ctx.Done\` case — the \`signal.Notify\` line is commented out — so the loop keeps running
3. A broadcast timer scheduled ~1.4s earlier fires → \`OnBroadcastProposal\` → \`OutgoingQueue.Add\` → panic writing to closed channel

**Fix:**
- \`outgoing_queue.go\`: add a \`done\` channel closed at shutdown; \`Add()\` uses \`select\` to bail out safely instead of sending to a closed channel
- \`reactor.go\` / \`pacemaker.go\`: store shutdown context in \`Reactor\`; add \`case <-ctx.Done()\` to \`mainLoop\` so it exits and cancels pending broadcast timers before the queue closes

### 2. Add \`--solo\` flag

Runs the node without any P2P activity — useful for local dev/testing:
- Discovery disabled, bootstrap nodes cleared, \`MaxPeers=0\`
- \`Communicator.Sync\` closes \`syncedCh\` immediately (no peer wait)
- Pacemaker starts right away without waiting to sync from the network

## Test plan
- [ ] Deploy to testnet and verify clean shutdown (`systemctl stop pos`) — no panic in logs
- [ ] Run with `--solo` and confirm no disco/sync attempts, consensus starts immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)