### PR TITLE
fix: route consensus messages to localhost in --solo mode

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -61,6 +61,7 @@ type ReactorConfig struct {
 	MaxCommitteeSize  int
 	MaxDelegateSize   int
 	InitDelegates     []*types.Delegate
+	Solo              bool
 }
 
 // -----------------------------------------------------------------------------
@@ -149,6 +150,7 @@ func NewConsensusReactor(ctx *cli.Context, chain *chain.Chain, logDB *logdb.LogD
 			MaxCommitteeSize:  ctx.Int("committee-max-size"),
 			MaxDelegateSize:   ctx.Int("delegate-max-size"),
 			InitDelegates:     initDelegates,
+			Solo:              ctx.Bool("solo"),
 		}
 	}
 
@@ -443,6 +445,15 @@ func (r *Reactor) GetConsensusDelegates() ([]*types.Delegate, []*types.Delegate)
 			r.delegateSource = fromDelegatesFile
 			r.peakFirst3Delegates("Loaded delegates from file as fallback", delegates)
 		}
+	}
+
+	// In solo mode, override all delegate IPs to localhost so consensus
+	// messages are routed locally regardless of what IP is registered on-chain.
+	if r.config.Solo {
+		for _, d := range delegates {
+			d.NetAddr.IP = net.ParseIP("127.0.0.1")
+		}
+		r.logger.Info("solo mode: overriding delegate IPs to 127.0.0.1 for consensus")
 	}
 
 	defer r.mapMutex.Unlock()


### PR DESCRIPTION
## Summary
In `--solo` mode, consensus messages are sent via HTTP to the IP addresses registered on-chain for each delegate. If the registered IP doesn't match the local machine, consensus fails even though the node is running as a single-node solo instance.

## Changes
- **`ReactorConfig`**: Added `Solo bool` field
- **`NewConsensusReactor`**: Populates `Solo` from `ctx.Bool("solo")`
- **`GetConsensusDelegates`**: When `Solo` is set, overrides all delegate `NetAddr.IP` to `127.0.0.1` after loading from staking or file

## Behaviour
- Keys (ECDSA + BLS) are still validated against on-chain registration — the node must be a registered delegate
- Only the IP used for consensus message routing is redirected to `127.0.0.1`
- No effect on non-solo mode

## Testing
- Start node with `--solo --api-addr 0.0.0.0:8669` where the registered delegate IP differs from the machine's local IP
- Consensus should proceed and blocks should be committed via localhost routing