### PR TITLE
Add native ETH JSON-RPC server (replaces meter-gear)

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -8,6 +8,7 @@ package ethapi
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/meterio/meter-pov/block"
 	"github.com/meterio/meter-pov/builtin"
 	"github.com/meterio/meter-pov/chain"
@@ -248,8 +250,17 @@ func (api *EthAPI) GetTransactionReceipt(hash common.Hash) (interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
+	// compute cumulativeGasUsed by summing all receipts up to this tx
+	allReceipts, _ := api.chain.GetBlockReceipts(txMeta.BlockID)
+	cumGasUsed := uint64(0)
+	for i, r := range allReceipts {
+		cumGasUsed += r.GasUsed
+		if uint64(i) == txMeta.Index {
+			break
+		}
+	}
 	baseGasPrice := api.getBaseGasPrice(header)
-	return meterReceiptToEthReceipt(receipt, t, txMeta, header, api.chainID, baseGasPrice), nil
+	return meterReceiptToEthReceipt(receipt, t, txMeta, header, api.chainID, baseGasPrice, cumGasUsed), nil
 }
 
 func (api *EthAPI) GetTransactionByBlockNumberAndIndex(blockNr string, index hexutil.Uint) (interface{}, error) {
@@ -371,41 +382,27 @@ func (api *EthAPI) GetLogs(filter LogFilterArgs) ([]interface{}, error) {
 	fromBlock := uint32(0)
 	toBlock := api.chain.BestBlock().Number()
 
-	if filter.FromBlock != nil {
-		n, err := api.blockNumberToUint32(*filter.FromBlock)
-		if err == nil {
-			fromBlock = n
+	if filter.BlockHash != nil {
+		header, err := api.chain.GetBlockHeader(meter.Bytes32(*filter.BlockHash))
+		if err != nil {
+			return nil, nil
 		}
-	}
-	if filter.ToBlock != nil {
-		n, err := api.blockNumberToUint32(*filter.ToBlock)
-		if err == nil {
-			toBlock = n
+		fromBlock = header.Number()
+		toBlock = header.Number()
+	} else {
+		if filter.FromBlock != nil {
+			if n, err := api.blockNumberToUint32(*filter.FromBlock); err == nil {
+				fromBlock = n
+			}
+		}
+		if filter.ToBlock != nil {
+			if n, err := api.blockNumberToUint32(*filter.ToBlock); err == nil {
+				toBlock = n
+			}
 		}
 	}
 
-	addresses := filter.Addresses
-	if len(addresses) == 0 {
-		return api.queryLogs(fromBlock, toBlock, nil, filter.Topics)
-	}
-	if len(addresses) <= 10 {
-		return api.queryLogs(fromBlock, toBlock, addresses, filter.Topics)
-	}
-	// Chunk addresses 10-at-a-time
-	var allLogs []interface{}
-	for i := 0; i < len(addresses); i += 10 {
-		end := i + 10
-		if end > len(addresses) {
-			end = len(addresses)
-		}
-		chunk := addresses[i:end]
-		logs, err := api.queryLogs(fromBlock, toBlock, chunk, filter.Topics)
-		if err != nil {
-			return nil, err
-		}
-		allLogs = append(allLogs, logs...)
-	}
-	return allLogs, nil
+	return api.queryLogs(fromBlock, toBlock, filter.Addresses, filter.Topics)
 }
 
 func (api *EthAPI) FeeHistory(blockCount hexutil.Uint64, newestBlock string, rewardPercentiles []float64) (map[string]interface{}, error) {
@@ -474,14 +471,103 @@ func (api *EthAPI) GetBlockReceipts(blockNr string) ([]interface{}, error) {
 	}
 	baseGasPrice := api.getBaseGasPrice(header)
 	result := make([]interface{}, 0, len(blk.Txs))
+	cumGasUsed := uint64(0)
 	for i, t := range blk.Txs {
 		if i >= len(receipts) {
 			break
 		}
+		cumGasUsed += receipts[i].GasUsed
 		meta := &chain.TxMeta{BlockID: header.ID(), Index: uint64(i)}
-		result = append(result, meterReceiptToEthReceipt(receipts[i], t, meta, header, api.chainID, baseGasPrice))
+		result = append(result, meterReceiptToEthReceipt(receipts[i], t, meta, header, api.chainID, baseGasPrice, cumGasUsed))
 	}
 	return result, nil
+}
+
+// ---------- WebSocket Subscriptions ----------
+
+// NewHeads sends a notification each time a new block is appended to the chain.
+// Mapped to eth_subscribe("newHeads") by the geth rpc.Server.
+func (api *EthAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	sub := notifier.CreateSubscription()
+	go func() {
+		ticker := api.chain.NewTicker()
+		for {
+			select {
+			case <-sub.Err():
+				return
+			case <-ticker.C():
+				best := api.chain.BestBlock()
+				blk, err := api.buildEthBlock(best, false)
+				if err != nil {
+					return
+				}
+				notifier.Notify(sub.ID, blk) //nolint:errcheck
+			}
+		}
+	}()
+	return sub, nil
+}
+
+// Logs sends a notification for each log matching the filter.
+// Mapped to eth_subscribe("logs", filter) by the geth rpc.Server.
+func (api *EthAPI) Logs(ctx context.Context, filter LogSubFilter) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+	sub := notifier.CreateSubscription()
+	go func() {
+		best := api.chain.BestBlock()
+		blockReader := api.chain.NewBlockReader(best.ID())
+		ticker := api.chain.NewTicker()
+		for {
+			blocks, err := blockReader.Read()
+			if err != nil {
+				return
+			}
+			for _, blk := range blocks {
+				header := blk.Header()
+				receipts, err := api.chain.GetBlockReceipts(blk.ID())
+				if err != nil {
+					continue
+				}
+				logIndex := 0
+				for i, receipt := range receipts {
+					if i >= len(blk.Txs) {
+						break
+					}
+					t := blk.Txs[i]
+					meta := &chain.TxMeta{BlockID: header.ID(), Index: uint64(i)}
+					for _, output := range receipt.Outputs {
+						for _, event := range output.Events {
+							if matchesLogFilter(event, filter) {
+								notifier.Notify(sub.ID, meterLogToEthLog(event, header, t, meta, logIndex)) //nolint:errcheck
+							}
+							logIndex++
+						}
+					}
+				}
+			}
+			if len(blocks) == 0 {
+				select {
+				case <-sub.Err():
+					return
+				case <-ticker.C():
+				}
+			} else {
+				select {
+				case <-sub.Err():
+					return
+				default:
+				}
+			}
+		}
+	}()
+	return sub, nil
 }
 
 // ---------- Net / Web3 / RPC / EVM ----------
@@ -528,6 +614,43 @@ func (api *EVMAPI) Revert(id string) bool {
 	return true
 }
 
+// ---------- Debug / Trace ----------
+
+// DebugAPI implements debug_* methods. Tracing requires a native tracer
+// implementation; for now these return stubs so clients don't hard-error.
+type DebugAPI struct{}
+
+func (api *DebugAPI) TraceTransaction(hash common.Hash, params interface{}) (interface{}, error) {
+	return map[string]interface{}{
+		"gas":         "0x0",
+		"returnValue": "",
+		"structLogs":  []interface{}{},
+	}, nil
+}
+
+func (api *DebugAPI) StorageRangeAt(blkHash common.Hash, txIndex int, addr common.Address, keyStart string, maxResult int) (interface{}, error) {
+	return map[string]interface{}{
+		"storage": map[string]interface{}{},
+		"nextKey": nil,
+	}, nil
+}
+
+// TraceAPI implements trace_* methods (Parity-style tracing).
+// These proxy calls are stubs until native tracing is implemented.
+type TraceAPI struct{}
+
+func (api *TraceAPI) Filter(filter interface{}) ([]interface{}, error) {
+	return []interface{}{}, nil
+}
+
+func (api *TraceAPI) Transaction(hash common.Hash) ([]interface{}, error) {
+	return []interface{}{}, nil
+}
+
+func (api *TraceAPI) Block(blockNr string) ([]interface{}, error) {
+	return []interface{}{}, nil
+}
+
 // ---------- Helpers ----------
 
 type CallArgs struct {
@@ -557,12 +680,71 @@ func (args CallArgs) dataBytes() []byte {
 	return nil
 }
 
+// TopicFilter handles the Ethereum topics encoding where each position can be
+// null (match any), a single hash, or an array of hashes (OR match).
+type TopicFilter [][]common.Hash
+
+func (t *TopicFilter) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	result := make([][]common.Hash, len(raw))
+	for i, r := range raw {
+		if string(r) == "null" {
+			result[i] = nil
+			continue
+		}
+		var single common.Hash
+		if err := json.Unmarshal(r, &single); err == nil {
+			result[i] = []common.Hash{single}
+			continue
+		}
+		var arr []common.Hash
+		if err := json.Unmarshal(r, &arr); err != nil {
+			return err
+		}
+		result[i] = arr
+	}
+	*t = TopicFilter(result)
+	return nil
+}
+
+// AddressOrArray handles a JSON field that can be a single address or array of addresses.
+type AddressOrArray []common.Address
+
+func (a *AddressOrArray) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	var single common.Address
+	if err := json.Unmarshal(data, &single); err == nil {
+		*a = AddressOrArray{single}
+		return nil
+	}
+	var arr []common.Address
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	*a = AddressOrArray(arr)
+	return nil
+}
+
 type LogFilterArgs struct {
-	FromBlock *string          `json:"fromBlock"`
-	ToBlock   *string          `json:"toBlock"`
-	Addresses []common.Address `json:"address"`
-	Topics    [][]common.Hash  `json:"topics"`
-	BlockHash *common.Hash     `json:"blockHash"`
+	FromBlock *string        `json:"fromBlock"`
+	ToBlock   *string        `json:"toBlock"`
+	Addresses AddressOrArray `json:"address"`
+	Topics    TopicFilter    `json:"topics"`
+	BlockHash *common.Hash   `json:"blockHash"`
+}
+
+// LogSubFilter is used for eth_subscribe("logs", filter).
+type LogSubFilter struct {
+	Addresses AddressOrArray `json:"address"`
+	Topics    TopicFilter    `json:"topics"`
 }
 
 func (api *EthAPI) execCall(args CallArgs, header *block.Header) (*runtime.Output, error) {
@@ -727,22 +909,7 @@ func (api *EthAPI) buildPendingTx(t *tx.Transaction) map[string]interface{} {
 }
 
 func (api *EthAPI) queryLogs(fromBlock, toBlock uint32, addresses []common.Address, topics [][]common.Hash) ([]interface{}, error) {
-	var criteriaSet []*logdb.EventCriteria
-
-	if len(addresses) == 0 && len(topics) == 0 {
-		criteriaSet = []*logdb.EventCriteria{{}}
-	} else if len(addresses) == 0 {
-		c := &logdb.EventCriteria{}
-		api.applyTopics(c, topics)
-		criteriaSet = []*logdb.EventCriteria{c}
-	} else {
-		for _, addr := range addresses {
-			a := meter.Address(addr)
-			c := &logdb.EventCriteria{Address: &a}
-			api.applyTopics(c, topics)
-			criteriaSet = append(criteriaSet, c)
-		}
-	}
+	criteriaSet := buildCriteriaSet(addresses, topics)
 
 	filter := &logdb.EventFilter{
 		CriteriaSet: criteriaSet,
@@ -761,15 +928,15 @@ func (api *EthAPI) queryLogs(fromBlock, toBlock uint32, addresses []common.Addre
 
 	result := make([]interface{}, 0, len(events))
 	for _, ev := range events {
-		topics := make([]string, 0)
+		evTopics := make([]string, 0)
 		for _, t := range ev.Topics {
 			if t != nil {
-				topics = append(topics, t.String())
+				evTopics = append(evTopics, t.String())
 			}
 		}
 		result = append(result, map[string]interface{}{
 			"address":          ev.Address.String(),
-			"topics":           topics,
+			"topics":           evTopics,
 			"data":             hexutil.Encode(ev.Data),
 			"blockHash":        ev.BlockID.String(),
 			"blockNumber":      hexUint64(uint64(ev.BlockNumber)),
@@ -782,12 +949,70 @@ func (api *EthAPI) queryLogs(fromBlock, toBlock uint32, addresses []common.Addre
 	return result, nil
 }
 
-func (api *EthAPI) applyTopics(c *logdb.EventCriteria, topics [][]common.Hash) {
+// buildCriteriaSet builds a logdb criteria set from addresses and topics,
+// correctly expanding OR-topic positions into multiple criteria.
+func buildCriteriaSet(addresses []common.Address, topics [][]common.Hash) []*logdb.EventCriteria {
+	// Start with one criteria per address (or one with no address filter).
+	bases := make([]*logdb.EventCriteria, 0)
+	if len(addresses) == 0 {
+		bases = append(bases, &logdb.EventCriteria{})
+	} else {
+		for _, addr := range addresses {
+			a := meter.Address(addr)
+			bases = append(bases, &logdb.EventCriteria{Address: &a})
+		}
+	}
+
+	// For each topic position, expand OR values into multiple criteria.
 	for i, topicList := range topics {
 		if i >= 5 || len(topicList) == 0 {
-			continue
+			continue // nil/empty means match any — leave criteria.Topics[i] as nil
 		}
-		t := meter.Bytes32(topicList[0])
-		c.Topics[i] = &t
+		expanded := make([]*logdb.EventCriteria, 0, len(bases)*len(topicList))
+		for _, base := range bases {
+			for _, topic := range topicList {
+				c := *base // shallow copy — safe since we only set new pointers
+				t := meter.Bytes32(topic)
+				c.Topics[i] = &t
+				expanded = append(expanded, &c)
+			}
+		}
+		bases = expanded
 	}
+	return bases
+}
+
+// matchesLogFilter reports whether an event matches a log subscription filter.
+func matchesLogFilter(event *tx.Event, filter LogSubFilter) bool {
+	if len(filter.Addresses) > 0 {
+		found := false
+		for _, addr := range filter.Addresses {
+			if meter.Address(addr) == event.Address {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	for i, topicList := range filter.Topics {
+		if len(topicList) == 0 {
+			continue // null = match any
+		}
+		if i >= len(event.Topics) {
+			return false
+		}
+		found := false
+		for _, topic := range topicList {
+			if meter.Bytes32(topic) == event.Topics[i] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -1,0 +1,793 @@
+// Copyright (c) 2020 The Meter.io developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package ethapi
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"math/rand"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/builtin"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/logdb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/runtime"
+	"github.com/meterio/meter-pov/state"
+	"github.com/meterio/meter-pov/tx"
+	"github.com/meterio/meter-pov/txpool"
+	"github.com/meterio/meter-pov/xenv"
+)
+
+// EthAPI implements the eth_* JSON-RPC methods.
+type EthAPI struct {
+	chain        *chain.Chain
+	stateCreator *state.Creator
+	txPool       *txpool.TxPool
+	logDB        *logdb.LogDB
+	chainID      *big.Int
+	callGasLimit uint64
+	logger       *slog.Logger
+
+	mu      sync.Mutex
+	filters map[string]*blockFilter
+}
+
+type blockFilter struct {
+	lastBlock uint32
+}
+
+func NewEthAPI(chain *chain.Chain, stateCreator *state.Creator, txPool *txpool.TxPool, logDB *logdb.LogDB, chainID *big.Int, callGasLimit uint64) *EthAPI {
+	return &EthAPI{
+		chain:        chain,
+		stateCreator: stateCreator,
+		txPool:       txPool,
+		logDB:        logDB,
+		chainID:      chainID,
+		callGasLimit: callGasLimit,
+		logger:       slog.With("api", "eth-rpc"),
+		filters:      make(map[string]*blockFilter),
+	}
+}
+
+// ---------- Trivial / Static ----------
+
+func (api *EthAPI) ChainId() string {
+	return hexBig(api.chainID)
+}
+
+func (api *EthAPI) GasPrice() (string, error) {
+	best := api.chain.BestBlock()
+	s, err := api.stateCreator.NewState(best.StateRoot())
+	if err != nil {
+		return "0x0", err
+	}
+	baseGasPrice := builtin.Params.Native(s).Get(meter.KeyBaseGasPrice)
+	return hexBig(baseGasPrice), nil
+}
+
+func (api *EthAPI) MaxPriorityFeePerGas() string {
+	return "0x0"
+}
+
+func (api *EthAPI) Syncing() (interface{}, error) {
+	return false, nil
+}
+
+// ---------- Simple ----------
+
+func (api *EthAPI) BlockNumber() string {
+	return hexUint64(uint64(api.chain.BestBlock().Number()))
+}
+
+func (api *EthAPI) GetBalance(addr common.Address, blockNrOrHash string) (string, error) {
+	header, err := api.resolveBlockNumber(blockNrOrHash)
+	if err != nil {
+		return "0x0", err
+	}
+	s, err := api.stateCreator.NewState(header.StateRoot())
+	if err != nil {
+		return "0x0", err
+	}
+	balance := s.GetBalance(meter.Address(addr))
+	if err := s.Err(); err != nil {
+		return "0x0", err
+	}
+	return hexBig(balance), nil
+}
+
+func (api *EthAPI) GetCode(addr common.Address, blockNrOrHash string) (string, error) {
+	header, err := api.resolveBlockNumber(blockNrOrHash)
+	if err != nil {
+		return "0x", err
+	}
+	s, err := api.stateCreator.NewState(header.StateRoot())
+	if err != nil {
+		return "0x", err
+	}
+	code := s.GetCode(meter.Address(addr))
+	if err := s.Err(); err != nil {
+		return "0x", err
+	}
+	return hexutil.Encode(code), nil
+}
+
+func (api *EthAPI) GetStorageAt(addr common.Address, key string, blockNrOrHash string) (string, error) {
+	header, err := api.resolveBlockNumber(blockNrOrHash)
+	if err != nil {
+		return "0x0", err
+	}
+	k, err := meter.ParseBytes32(key)
+	if err != nil {
+		return "0x0", fmt.Errorf("invalid storage key: %v", err)
+	}
+	s, err := api.stateCreator.NewState(header.StateRoot())
+	if err != nil {
+		return "0x0", err
+	}
+	storage := s.GetStorage(meter.Address(addr), k)
+	if err := s.Err(); err != nil {
+		return "0x0", err
+	}
+	return storage.String(), nil
+}
+
+func (api *EthAPI) GetTransactionCount(addr common.Address, blockNrOrHash string) string {
+	// Meter doesn't track nonces like Ethereum. Return random nonce (matches gear behavior).
+	return hexUint64(rand.Uint64())
+}
+
+func (api *EthAPI) NewBlockFilter() string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	id := fmt.Sprintf("0x%x", rand.Int63())
+	api.filters[id] = &blockFilter{lastBlock: api.chain.BestBlock().Number()}
+	return id
+}
+
+func (api *EthAPI) UninstallFilter(id string) bool {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	_, ok := api.filters[id]
+	delete(api.filters, id)
+	return ok
+}
+
+func (api *EthAPI) GetFilterChanges(id string) ([]string, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	f, ok := api.filters[id]
+	if !ok {
+		return []string{}, fmt.Errorf("filter not found")
+	}
+	best := api.chain.BestBlock().Number()
+	var hashes []string
+	for i := f.lastBlock + 1; i <= best; i++ {
+		blk, err := api.chain.GetTrunkBlock(i)
+		if err != nil {
+			break
+		}
+		hashes = append(hashes, blk.ID().String())
+	}
+	f.lastBlock = best
+	return hashes, nil
+}
+
+// ---------- Medium ----------
+
+func (api *EthAPI) GetBlockByNumber(blockNr string, fullTx bool) (interface{}, error) {
+	header, err := api.resolveBlockNumber(blockNr)
+	if err != nil {
+		return nil, nil
+	}
+	blk, err := api.chain.GetBlock(header.ID())
+	if err != nil {
+		return nil, nil
+	}
+	return api.buildEthBlock(blk, fullTx)
+}
+
+func (api *EthAPI) GetBlockByHash(hash common.Hash, fullTx bool) (interface{}, error) {
+	blockID := meter.Bytes32(hash)
+	blk, err := api.chain.GetBlock(blockID)
+	if err != nil {
+		return nil, nil
+	}
+	return api.buildEthBlock(blk, fullTx)
+}
+
+func (api *EthAPI) GetTransactionByHash(hash common.Hash) (interface{}, error) {
+	txID := meter.Bytes32(hash)
+	t, txMeta, err := api.chain.GetTrunkTransaction(txID)
+	if err != nil {
+		if api.chain.IsNotFound(err) {
+			if pending := api.txPool.Get(txID); pending != nil {
+				return api.buildPendingTx(pending), nil
+			}
+			return nil, nil
+		}
+		return nil, err
+	}
+	header, err := api.chain.GetBlockHeader(txMeta.BlockID)
+	if err != nil {
+		return nil, err
+	}
+	baseGasPrice := api.getBaseGasPrice(header)
+	return meterTxToEthTx(t, txMeta, header, api.chainID, baseGasPrice, nil), nil
+}
+
+func (api *EthAPI) GetTransactionReceipt(hash common.Hash) (interface{}, error) {
+	txID := meter.Bytes32(hash)
+	t, txMeta, err := api.chain.GetTrunkTransaction(txID)
+	if err != nil {
+		if api.chain.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	header, err := api.chain.GetBlockHeader(txMeta.BlockID)
+	if err != nil {
+		return nil, err
+	}
+	best := api.chain.BestBlock()
+	if header.Number() > best.Number() {
+		return nil, nil
+	}
+	receipt, err := api.chain.GetTransactionReceipt(txMeta.BlockID, txMeta.Index)
+	if err != nil {
+		return nil, err
+	}
+	baseGasPrice := api.getBaseGasPrice(header)
+	return meterReceiptToEthReceipt(receipt, t, txMeta, header, api.chainID, baseGasPrice), nil
+}
+
+func (api *EthAPI) GetTransactionByBlockNumberAndIndex(blockNr string, index hexutil.Uint) (interface{}, error) {
+	header, err := api.resolveBlockNumber(blockNr)
+	if err != nil {
+		return nil, nil
+	}
+	blk, err := api.chain.GetBlock(header.ID())
+	if err != nil {
+		return nil, nil
+	}
+	txs := blk.Txs
+	if int(index) >= len(txs) {
+		return nil, nil
+	}
+	t := txs[int(index)]
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: uint64(index)}
+	baseGasPrice := api.getBaseGasPrice(header)
+	return meterTxToEthTx(t, meta, header, api.chainID, baseGasPrice, nil), nil
+}
+
+func (api *EthAPI) GetTransactionByBlockHashAndIndex(hash common.Hash, index hexutil.Uint) (interface{}, error) {
+	blockID := meter.Bytes32(hash)
+	blk, err := api.chain.GetBlock(blockID)
+	if err != nil {
+		return nil, nil
+	}
+	header := blk.Header()
+	txs := blk.Txs
+	if int(index) >= len(txs) {
+		return nil, nil
+	}
+	t := txs[int(index)]
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: uint64(index)}
+	baseGasPrice := api.getBaseGasPrice(header)
+	return meterTxToEthTx(t, meta, header, api.chainID, baseGasPrice, nil), nil
+}
+
+func (api *EthAPI) GetBlockTransactionCountByNumber(blockNr string) (string, error) {
+	header, err := api.resolveBlockNumber(blockNr)
+	if err != nil {
+		return "0x0", nil
+	}
+	blk, err := api.chain.GetBlock(header.ID())
+	if err != nil {
+		return "0x0", nil
+	}
+	return hexUint64(uint64(len(blk.Txs))), nil
+}
+
+func (api *EthAPI) Call(args CallArgs, blockNrOrHash string) (string, error) {
+	header, err := api.resolveBlockNumber(blockNrOrHash)
+	if err != nil {
+		return "0x", err
+	}
+	output, err := api.execCall(args, header)
+	if err != nil {
+		return "0x", err
+	}
+	return hexutil.Encode(output.Data), nil
+}
+
+func (api *EthAPI) EstimateGas(args CallArgs, blockNrOrHash *string) (string, error) {
+	blockNr := "latest"
+	if blockNrOrHash != nil {
+		blockNr = *blockNrOrHash
+	}
+	header, err := api.resolveBlockNumber(blockNr)
+	if err != nil {
+		return "0x0", err
+	}
+	output, err := api.execCall(args, header)
+	if err != nil {
+		return "0x0", err
+	}
+
+	gasUsed := args.gasLimit() - output.LeftOverGas
+	// Add intrinsic gas
+	data := args.dataBytes()
+	intrinsic := uint64(21000)
+	for _, b := range data {
+		if b == 0 {
+			intrinsic += 4
+		} else {
+			intrinsic += 16
+		}
+	}
+	total := gasUsed + intrinsic
+	// Add 30% buffer
+	total = total * 13 / 10
+	return hexUint64(total), nil
+}
+
+func (api *EthAPI) SendRawTransaction(rawTx string) (string, error) {
+	raw, err := hex.DecodeString(strings.TrimPrefix(rawTx, "0x"))
+	if err != nil {
+		return "", fmt.Errorf("invalid raw tx: %v", err)
+	}
+	ethTx := types.Transaction{}
+	if err := ethTx.UnmarshalBinary(raw); err != nil {
+		return "", fmt.Errorf("decode tx: %v", err)
+	}
+	best := api.chain.BestBlock()
+	genID, _ := api.chain.GetAncestorBlockID(best.Header().ID(), 0)
+	chainTag := genID[len(genID)-1]
+	blockRef := tx.NewBlockRefFromID(best.ID())
+	nativeTx, err := tx.NewTransactionFromEthTx(&ethTx, chainTag, blockRef, true)
+	if err != nil {
+		return "", fmt.Errorf("convert tx: %v", err)
+	}
+	if err := api.txPool.Add(nativeTx); err != nil {
+		api.logger.Warn("failed to add tx to pool", "err", err)
+		return "", err
+	}
+	return nativeTx.ID().String(), nil
+}
+
+func (api *EthAPI) GetLogs(filter LogFilterArgs) ([]interface{}, error) {
+	fromBlock := uint32(0)
+	toBlock := api.chain.BestBlock().Number()
+
+	if filter.FromBlock != nil {
+		n, err := api.blockNumberToUint32(*filter.FromBlock)
+		if err == nil {
+			fromBlock = n
+		}
+	}
+	if filter.ToBlock != nil {
+		n, err := api.blockNumberToUint32(*filter.ToBlock)
+		if err == nil {
+			toBlock = n
+		}
+	}
+
+	addresses := filter.Addresses
+	if len(addresses) == 0 {
+		return api.queryLogs(fromBlock, toBlock, nil, filter.Topics)
+	}
+	if len(addresses) <= 10 {
+		return api.queryLogs(fromBlock, toBlock, addresses, filter.Topics)
+	}
+	// Chunk addresses 10-at-a-time
+	var allLogs []interface{}
+	for i := 0; i < len(addresses); i += 10 {
+		end := i + 10
+		if end > len(addresses) {
+			end = len(addresses)
+		}
+		chunk := addresses[i:end]
+		logs, err := api.queryLogs(fromBlock, toBlock, chunk, filter.Topics)
+		if err != nil {
+			return nil, err
+		}
+		allLogs = append(allLogs, logs...)
+	}
+	return allLogs, nil
+}
+
+func (api *EthAPI) FeeHistory(blockCount hexutil.Uint64, newestBlock string, rewardPercentiles []float64) (map[string]interface{}, error) {
+	header, err := api.resolveBlockNumber(newestBlock)
+	if err != nil {
+		return nil, err
+	}
+	count := uint64(blockCount)
+	if count > 1024 {
+		count = 1024
+	}
+	endNum := uint64(header.Number())
+	startNum := uint64(0)
+	if endNum >= count {
+		startNum = endNum - count + 1
+	}
+
+	baseFees := make([]string, 0, count+1)
+	gasUsedRatios := make([]float64, 0, count)
+
+	for i := startNum; i <= endNum; i++ {
+		h, err := api.chain.GetTrunkBlockHeader(uint32(i))
+		if err != nil {
+			baseFees = append(baseFees, "0x0")
+			gasUsedRatios = append(gasUsedRatios, 0)
+			continue
+		}
+		s, err := api.stateCreator.NewState(h.StateRoot())
+		if err != nil {
+			baseFees = append(baseFees, "0x0")
+			gasUsedRatios = append(gasUsedRatios, 0)
+			continue
+		}
+		baseGas := builtin.Params.Native(s).Get(meter.KeyBaseGasPrice)
+		baseFees = append(baseFees, hexBig(baseGas))
+		gasLimit := h.GasLimit()
+		gasUsed := h.GasUsed()
+		ratio := float64(0)
+		if gasLimit > 0 {
+			ratio = float64(gasUsed) / float64(gasLimit)
+		}
+		gasUsedRatios = append(gasUsedRatios, ratio)
+	}
+	// One extra baseFee for the next block
+	baseFees = append(baseFees, baseFees[len(baseFees)-1])
+
+	return map[string]interface{}{
+		"oldestBlock":  hexUint64(startNum),
+		"baseFeePerGas": baseFees,
+		"gasUsedRatio":  gasUsedRatios,
+	}, nil
+}
+
+func (api *EthAPI) GetBlockReceipts(blockNr string) ([]interface{}, error) {
+	header, err := api.resolveBlockNumber(blockNr)
+	if err != nil {
+		return nil, nil
+	}
+	blk, err := api.chain.GetBlock(header.ID())
+	if err != nil {
+		return nil, nil
+	}
+	receipts, err := api.chain.GetBlockReceipts(header.ID())
+	if err != nil {
+		return nil, err
+	}
+	baseGasPrice := api.getBaseGasPrice(header)
+	result := make([]interface{}, 0, len(blk.Txs))
+	for i, t := range blk.Txs {
+		if i >= len(receipts) {
+			break
+		}
+		meta := &chain.TxMeta{BlockID: header.ID(), Index: uint64(i)}
+		result = append(result, meterReceiptToEthReceipt(receipts[i], t, meta, header, api.chainID, baseGasPrice))
+	}
+	return result, nil
+}
+
+// ---------- Net / Web3 / RPC / EVM ----------
+
+type NetAPI struct {
+	chainID *big.Int
+}
+
+func (api *NetAPI) Version() string {
+	return api.chainID.String()
+}
+
+func (api *NetAPI) Listening() bool {
+	return false
+}
+
+func (api *NetAPI) PeerCount() string {
+	return "0x0"
+}
+
+type Web3API struct{}
+
+func (api *Web3API) ClientVersion() string {
+	return "meter-pov/v1.0"
+}
+
+type RPCAPI struct{}
+
+func (api *RPCAPI) Modules() map[string]string {
+	return map[string]string{
+		"eth":  "1.0",
+		"net":  "1.0",
+		"web3": "1.0",
+	}
+}
+
+type EVMAPI struct{}
+
+func (api *EVMAPI) Snapshot() string {
+	return "0x0"
+}
+
+func (api *EVMAPI) Revert(id string) bool {
+	return true
+}
+
+// ---------- Helpers ----------
+
+type CallArgs struct {
+	From     *common.Address `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Data     *hexutil.Bytes  `json:"data"`
+	Input    *hexutil.Bytes  `json:"input"`
+}
+
+func (args CallArgs) gasLimit() uint64 {
+	if args.Gas != nil {
+		return uint64(*args.Gas)
+	}
+	return 0
+}
+
+func (args CallArgs) dataBytes() []byte {
+	if args.Input != nil {
+		return []byte(*args.Input)
+	}
+	if args.Data != nil {
+		return []byte(*args.Data)
+	}
+	return nil
+}
+
+type LogFilterArgs struct {
+	FromBlock *string          `json:"fromBlock"`
+	ToBlock   *string          `json:"toBlock"`
+	Addresses []common.Address `json:"address"`
+	Topics    [][]common.Hash  `json:"topics"`
+	BlockHash *common.Hash     `json:"blockHash"`
+}
+
+func (api *EthAPI) execCall(args CallArgs, header *block.Header) (*runtime.Output, error) {
+	s, err := api.stateCreator.NewState(header.StateRoot())
+	if err != nil {
+		return nil, err
+	}
+	signer, _ := header.Signer()
+	rt := runtime.New(api.chain.NewSeeker(header.ParentID()), s,
+		&xenv.BlockContext{
+			Beneficiary: header.Beneficiary(),
+			Signer:      signer,
+			Number:      header.Number(),
+			Time:        header.Timestamp(),
+			GasLimit:    header.GasLimit(),
+			TotalScore:  header.TotalScore(),
+		})
+
+	gas := api.callGasLimit
+	if args.Gas != nil && uint64(*args.Gas) > 0 {
+		gas = uint64(*args.Gas)
+	}
+	if gas > api.callGasLimit {
+		gas = api.callGasLimit
+	}
+
+	var to *meter.Address
+	if args.To != nil {
+		a := meter.Address(*args.To)
+		to = &a
+	}
+	var value *big.Int
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	} else {
+		value = new(big.Int)
+	}
+	var gasPrice *big.Int
+	if args.GasPrice != nil {
+		gasPrice = args.GasPrice.ToInt()
+	} else {
+		gasPrice = new(big.Int)
+	}
+
+	data := args.dataBytes()
+	clause := tx.NewClause(to).WithValue(value).WithData(data)
+
+	origin := meter.Address{}
+	if args.From != nil {
+		origin = meter.Address(*args.From)
+	}
+	best := api.chain.BestBlock()
+	blockRef := tx.NewBlockRefFromID(best.ID())
+
+	exec, _ := rt.PrepareClause(clause, 0, gas, &xenv.TransactionContext{
+		Origin:     origin,
+		GasPrice:   gasPrice,
+		BlockRef:   blockRef,
+		Nonce:      rand.Uint64(),
+		ProvedWork: new(big.Int),
+	})
+
+	out, _ := exec()
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (api *EthAPI) resolveBlockNumber(blockNr string) (*block.Header, error) {
+	switch blockNr {
+	case "", "latest", "pending", "safe", "finalized":
+		return api.chain.BestBlock().Header(), nil
+	case "earliest":
+		return api.chain.GenesisBlock().Header(), nil
+	default:
+		n, err := hexutil.DecodeUint64(blockNr)
+		if err != nil {
+			// Try as block hash
+			blockID, err2 := meter.ParseBytes32(blockNr)
+			if err2 != nil {
+				return nil, fmt.Errorf("invalid block number: %v", err)
+			}
+			return api.chain.GetBlockHeader(blockID)
+		}
+		return api.chain.GetTrunkBlockHeader(uint32(n))
+	}
+}
+
+func (api *EthAPI) blockNumberToUint32(blockNr string) (uint32, error) {
+	switch blockNr {
+	case "", "latest", "pending", "safe", "finalized":
+		return api.chain.BestBlock().Number(), nil
+	case "earliest":
+		return 0, nil
+	default:
+		n, err := hexutil.DecodeUint64(blockNr)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(n), nil
+	}
+}
+
+func (api *EthAPI) getBaseGasPrice(header *block.Header) *big.Int {
+	s, err := api.stateCreator.NewState(header.StateRoot())
+	if err != nil {
+		return new(big.Int)
+	}
+	return builtin.Params.Native(s).Get(meter.KeyBaseGasPrice)
+}
+
+func (api *EthAPI) buildEthBlock(blk *block.Block, fullTx bool) (map[string]interface{}, error) {
+	header := blk.Header()
+	var receipts tx.Receipts
+	if blk.ID().String() != api.chain.GenesisBlock().ID().String() {
+		var err error
+		receipts, err = api.chain.GetBlockReceipts(blk.ID())
+		if err != nil {
+			receipts = make([]*tx.Receipt, 0)
+		}
+	}
+	baseGasPrice := api.getBaseGasPrice(header)
+	return meterBlockToEthBlock(blk, receipts, fullTx, api.chainID, baseGasPrice), nil
+}
+
+func (api *EthAPI) buildPendingTx(t *tx.Transaction) map[string]interface{} {
+	origin, _ := t.Signer()
+	clauses := t.Clauses()
+	var to interface{}
+	value := "0x0"
+	input := "0x"
+	if len(clauses) > 0 {
+		c := clauses[0]
+		if c.To() != nil {
+			to = c.To().String()
+		}
+		if c.Value() != nil {
+			value = hexBig(c.Value())
+		}
+		if len(c.Data()) > 0 {
+			input = hexutil.Encode(c.Data())
+		}
+	}
+	baseGasPrice := api.getBaseGasPrice(api.chain.BestBlock().Header())
+	gasPrice := t.GasPrice(baseGasPrice)
+	return map[string]interface{}{
+		"hash":             t.ID().String(),
+		"blockHash":        nil,
+		"blockNumber":      nil,
+		"transactionIndex": nil,
+		"from":             origin.String(),
+		"to":               to,
+		"value":            value,
+		"input":            input,
+		"gas":              hexUint64(t.Gas()),
+		"gasPrice":         hexBig(gasPrice),
+		"nonce":            hexUint64(t.Nonce()),
+		"type":             "0x0",
+		"chainId":          hexBig(api.chainID),
+	}
+}
+
+func (api *EthAPI) queryLogs(fromBlock, toBlock uint32, addresses []common.Address, topics [][]common.Hash) ([]interface{}, error) {
+	var criteriaSet []*logdb.EventCriteria
+
+	if len(addresses) == 0 && len(topics) == 0 {
+		criteriaSet = []*logdb.EventCriteria{{}}
+	} else if len(addresses) == 0 {
+		c := &logdb.EventCriteria{}
+		api.applyTopics(c, topics)
+		criteriaSet = []*logdb.EventCriteria{c}
+	} else {
+		for _, addr := range addresses {
+			a := meter.Address(addr)
+			c := &logdb.EventCriteria{Address: &a}
+			api.applyTopics(c, topics)
+			criteriaSet = append(criteriaSet, c)
+		}
+	}
+
+	filter := &logdb.EventFilter{
+		CriteriaSet: criteriaSet,
+		Range: &logdb.Range{
+			Unit: logdb.Block,
+			From: uint64(fromBlock),
+			To:   uint64(toBlock),
+		},
+		Order: logdb.ASC,
+	}
+
+	events, err := api.logDB.FilterEvents(context.Background(), filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]interface{}, 0, len(events))
+	for _, ev := range events {
+		topics := make([]string, 0)
+		for _, t := range ev.Topics {
+			if t != nil {
+				topics = append(topics, t.String())
+			}
+		}
+		result = append(result, map[string]interface{}{
+			"address":          ev.Address.String(),
+			"topics":           topics,
+			"data":             hexutil.Encode(ev.Data),
+			"blockHash":        ev.BlockID.String(),
+			"blockNumber":      hexUint64(uint64(ev.BlockNumber)),
+			"transactionHash":  ev.TxID.String(),
+			"transactionIndex": hexUint64(uint64(ev.Index)),
+			"logIndex":         hexUint64(uint64(ev.Index)),
+			"removed":          false,
+		})
+	}
+	return result, nil
+}
+
+func (api *EthAPI) applyTopics(c *logdb.EventCriteria, topics [][]common.Hash) {
+	for i, topicList := range topics {
+		if i >= 5 || len(topicList) == 0 {
+			continue
+		}
+		t := meter.Bytes32(topicList[0])
+		c.Topics[i] = &t
+	}
+}

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -130,6 +130,9 @@ func (api *EthAPI) GetStorageAt(addr common.Address, key string, blockNrOrHash s
 	if err != nil {
 		return "0x0", err
 	}
+	// Pad key to 32 bytes (clients may send "0x1" instead of "0x000...001").
+	key = strings.TrimPrefix(key, "0x")
+	key = fmt.Sprintf("0x%064s", key)
 	k, err := meter.ParseBytes32(key)
 	if err != nil {
 		return "0x0", fmt.Errorf("invalid storage key: %v", err)
@@ -311,6 +314,16 @@ func (api *EthAPI) GetBlockTransactionCountByNumber(blockNr string) (string, err
 	return hexUint64(uint64(len(blk.Txs))), nil
 }
 
+// revertError implements rpc.DataError so geth serialises it as code=3 with data.
+type revertError struct {
+	reason string
+	data   string
+}
+
+func (e *revertError) Error() string      { return "execution reverted: " + e.reason }
+func (e *revertError) ErrorCode() int     { return 3 }
+func (e *revertError) ErrorData() interface{} { return e.data }
+
 func (api *EthAPI) Call(args CallArgs, blockNrOrHash string) (string, error) {
 	header, err := api.resolveBlockNumber(blockNrOrHash)
 	if err != nil {
@@ -319,6 +332,9 @@ func (api *EthAPI) Call(args CallArgs, blockNrOrHash string) (string, error) {
 	output, err := api.execCall(args, header)
 	if err != nil {
 		return "0x", err
+	}
+	if output.VMErr != nil {
+		return "0x", &revertError{reason: output.VMErr.Error(), data: hexutil.Encode(output.Data)}
 	}
 	return hexutil.Encode(output.Data), nil
 }
@@ -336,8 +352,16 @@ func (api *EthAPI) EstimateGas(args CallArgs, blockNrOrHash *string) (string, er
 	if err != nil {
 		return "0x0", err
 	}
+	if output.VMErr != nil {
+		return "0x0", &revertError{reason: output.VMErr.Error(), data: hexutil.Encode(output.Data)}
+	}
 
-	gasUsed := args.gasLimit() - output.LeftOverGas
+	// Determine the gas limit actually used by execCall.
+	effectiveGasLimit := api.callGasLimit
+	if args.Gas != nil && uint64(*args.Gas) > 0 && uint64(*args.Gas) < api.callGasLimit {
+		effectiveGasLimit = uint64(*args.Gas)
+	}
+	gasUsed := effectiveGasLimit - output.LeftOverGas
 	// Add intrinsic gas
 	data := args.dataBytes()
 	intrinsic := uint64(21000)
@@ -422,18 +446,21 @@ func (api *EthAPI) FeeHistory(blockCount hexutil.Uint64, newestBlock string, rew
 
 	baseFees := make([]string, 0, count+1)
 	gasUsedRatios := make([]float64, 0, count)
+	rewards := make([][]string, 0, count)
 
 	for i := startNum; i <= endNum; i++ {
 		h, err := api.chain.GetTrunkBlockHeader(uint32(i))
 		if err != nil {
 			baseFees = append(baseFees, "0x0")
 			gasUsedRatios = append(gasUsedRatios, 0)
+			rewards = append(rewards, emptyRewards(rewardPercentiles))
 			continue
 		}
 		s, err := api.stateCreator.NewState(h.StateRoot())
 		if err != nil {
 			baseFees = append(baseFees, "0x0")
 			gasUsedRatios = append(gasUsedRatios, 0)
+			rewards = append(rewards, emptyRewards(rewardPercentiles))
 			continue
 		}
 		baseGas := builtin.Params.Native(s).Get(meter.KeyBaseGasPrice)
@@ -445,14 +472,16 @@ func (api *EthAPI) FeeHistory(blockCount hexutil.Uint64, newestBlock string, rew
 			ratio = float64(gasUsed) / float64(gasLimit)
 		}
 		gasUsedRatios = append(gasUsedRatios, ratio)
+		rewards = append(rewards, emptyRewards(rewardPercentiles))
 	}
 	// One extra baseFee for the next block
 	baseFees = append(baseFees, baseFees[len(baseFees)-1])
 
 	return map[string]interface{}{
-		"oldestBlock":  hexUint64(startNum),
+		"oldestBlock":   hexUint64(startNum),
 		"baseFeePerGas": baseFees,
 		"gasUsedRatio":  gasUsedRatios,
+		"reward":        rewards,
 	}, nil
 }
 
@@ -906,6 +935,14 @@ func (api *EthAPI) buildPendingTx(t *tx.Transaction) map[string]interface{} {
 		"type":             "0x0",
 		"chainId":          hexBig(api.chainID),
 	}
+}
+
+func emptyRewards(percentiles []float64) []string {
+	r := make([]string, len(percentiles))
+	for i := range r {
+		r[i] = "0x0"
+	}
+	return r
 }
 
 func (api *EthAPI) queryLogs(fromBlock, toBlock uint32, addresses []common.Address, topics [][]common.Hash) ([]interface{}, error) {

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -1,0 +1,338 @@
+package ethapi
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/meterio/meter-pov/logdb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------- CallArgs tests ----------
+
+func TestCallArgs_GasLimit(t *testing.T) {
+	// nil gas
+	args := CallArgs{}
+	assert.Equal(t, uint64(0), args.gasLimit())
+
+	// with gas
+	gas := hexutil.Uint64(50000)
+	args = CallArgs{Gas: &gas}
+	assert.Equal(t, uint64(50000), args.gasLimit())
+}
+
+func TestCallArgs_DataBytes(t *testing.T) {
+	// nil data and input
+	args := CallArgs{}
+	assert.Nil(t, args.dataBytes())
+
+	// with Data
+	data := hexutil.Bytes([]byte{0x01, 0x02})
+	args = CallArgs{Data: &data}
+	assert.Equal(t, []byte{0x01, 0x02}, args.dataBytes())
+
+	// with Input (takes priority)
+	input := hexutil.Bytes([]byte{0x03, 0x04})
+	args = CallArgs{Data: &data, Input: &input}
+	assert.Equal(t, []byte{0x03, 0x04}, args.dataBytes())
+
+	// only Input
+	args = CallArgs{Input: &input}
+	assert.Equal(t, []byte{0x03, 0x04}, args.dataBytes())
+}
+
+func TestCallArgs_DataBytes_Empty(t *testing.T) {
+	data := hexutil.Bytes([]byte{})
+	args := CallArgs{Data: &data}
+	assert.Equal(t, []byte{}, args.dataBytes())
+}
+
+// ---------- LogFilterArgs JSON tests ----------
+
+func TestLogFilterArgs_JSONUnmarshal(t *testing.T) {
+	jsonStr := `{
+		"fromBlock": "0x1",
+		"toBlock": "0x100",
+		"address": ["0x0000000000000000000000000000000000000001"],
+		"topics": [["0x0000000000000000000000000000000000000000000000000000000000000001"]]
+	}`
+
+	var filter LogFilterArgs
+	err := json.Unmarshal([]byte(jsonStr), &filter)
+	assert.NoError(t, err)
+	assert.NotNil(t, filter.FromBlock)
+	assert.Equal(t, "0x1", *filter.FromBlock)
+	assert.NotNil(t, filter.ToBlock)
+	assert.Equal(t, "0x100", *filter.ToBlock)
+	assert.Equal(t, 1, len(filter.Addresses))
+	assert.Equal(t, 1, len(filter.Topics))
+}
+
+func TestLogFilterArgs_JSONUnmarshal_Minimal(t *testing.T) {
+	jsonStr := `{}`
+	var filter LogFilterArgs
+	err := json.Unmarshal([]byte(jsonStr), &filter)
+	assert.NoError(t, err)
+	assert.Nil(t, filter.FromBlock)
+	assert.Nil(t, filter.ToBlock)
+	assert.Nil(t, filter.Addresses)
+	assert.Nil(t, filter.Topics)
+}
+
+// ---------- NetAPI tests ----------
+
+func TestNetAPI_Version(t *testing.T) {
+	api := &NetAPI{chainID: big.NewInt(82)}
+	assert.Equal(t, "82", api.Version())
+
+	api = &NetAPI{chainID: big.NewInt(83)}
+	assert.Equal(t, "83", api.Version())
+}
+
+func TestNetAPI_Listening(t *testing.T) {
+	api := &NetAPI{chainID: big.NewInt(82)}
+	assert.False(t, api.Listening())
+}
+
+func TestNetAPI_PeerCount(t *testing.T) {
+	api := &NetAPI{chainID: big.NewInt(82)}
+	assert.Equal(t, "0x0", api.PeerCount())
+}
+
+// ---------- Web3API tests ----------
+
+func TestWeb3API_ClientVersion(t *testing.T) {
+	api := &Web3API{}
+	v := api.ClientVersion()
+	assert.Contains(t, v, "meter-pov")
+}
+
+// ---------- RPCAPI tests ----------
+
+func TestRPCAPI_Modules(t *testing.T) {
+	api := &RPCAPI{}
+	modules := api.Modules()
+	assert.Equal(t, "1.0", modules["eth"])
+	assert.Equal(t, "1.0", modules["net"])
+	assert.Equal(t, "1.0", modules["web3"])
+	assert.Equal(t, 3, len(modules))
+}
+
+// ---------- EVMAPI tests ----------
+
+func TestEVMAPI_Snapshot(t *testing.T) {
+	api := &EVMAPI{}
+	assert.Equal(t, "0x0", api.Snapshot())
+}
+
+func TestEVMAPI_Revert(t *testing.T) {
+	api := &EVMAPI{}
+	assert.True(t, api.Revert("0x1"))
+	assert.True(t, api.Revert("anything"))
+}
+
+// ---------- EthAPI static method tests ----------
+
+func TestEthAPI_ChainId(t *testing.T) {
+	api := &EthAPI{chainID: big.NewInt(82)}
+	assert.Equal(t, "0x52", api.ChainId())
+
+	api = &EthAPI{chainID: big.NewInt(83)}
+	assert.Equal(t, "0x53", api.ChainId())
+}
+
+func TestEthAPI_MaxPriorityFeePerGas(t *testing.T) {
+	api := &EthAPI{}
+	assert.Equal(t, "0x0", api.MaxPriorityFeePerGas())
+}
+
+func TestEthAPI_Syncing(t *testing.T) {
+	api := &EthAPI{}
+	result, err := api.Syncing()
+	assert.NoError(t, err)
+	assert.Equal(t, false, result)
+}
+
+func TestEthAPI_GetTransactionCount(t *testing.T) {
+	api := &EthAPI{}
+	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+
+	result1 := api.GetTransactionCount(addr, "latest")
+	result2 := api.GetTransactionCount(addr, "latest")
+
+	// Should return hex strings
+	assert.Equal(t, "0x", result1[:2])
+	assert.Equal(t, "0x", result2[:2])
+	// Random, so they should almost certainly differ (1 in 2^64 chance of collision)
+	// Skip equality check as it's probabilistic
+}
+
+// ---------- Filter management tests ----------
+
+func TestEthAPI_FilterLifecycle(t *testing.T) {
+	// We can't use NewBlockFilter without a chain, but we can test UninstallFilter
+	api := &EthAPI{
+		filters: make(map[string]*blockFilter),
+	}
+
+	// Manually insert a filter
+	api.filters["0x123"] = &blockFilter{lastBlock: 100}
+
+	// UninstallFilter existing
+	assert.True(t, api.UninstallFilter("0x123"))
+
+	// UninstallFilter non-existing
+	assert.False(t, api.UninstallFilter("0x123"))
+	assert.False(t, api.UninstallFilter("0xnonexistent"))
+}
+
+func TestEthAPI_GetFilterChanges_NotFound(t *testing.T) {
+	api := &EthAPI{
+		filters: make(map[string]*blockFilter),
+	}
+
+	hashes, err := api.GetFilterChanges("0xnonexistent")
+	assert.Error(t, err)
+	assert.Equal(t, []string{}, hashes)
+}
+
+// ---------- applyTopics tests ----------
+
+func TestApplyTopics(t *testing.T) {
+	api := &EthAPI{}
+
+	t.Run("empty topics", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		api.applyTopics(c, nil)
+		for _, topic := range c.Topics {
+			assert.Nil(t, topic)
+		}
+	})
+
+	t.Run("single topic", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		topicHash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+		api.applyTopics(c, [][]common.Hash{{topicHash}})
+		assert.NotNil(t, c.Topics[0])
+		assert.Equal(t, meter.Bytes32(topicHash), *c.Topics[0])
+		assert.Nil(t, c.Topics[1])
+	})
+
+	t.Run("multiple topics", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		topic0 := common.HexToHash("0xaaaa")
+		topic1 := common.HexToHash("0xbbbb")
+		topic2 := common.HexToHash("0xcccc")
+		api.applyTopics(c, [][]common.Hash{{topic0}, {topic1}, {topic2}})
+		assert.NotNil(t, c.Topics[0])
+		assert.NotNil(t, c.Topics[1])
+		assert.NotNil(t, c.Topics[2])
+		assert.Nil(t, c.Topics[3])
+		assert.Nil(t, c.Topics[4])
+	})
+
+	t.Run("empty topic list skipped", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		topic1 := common.HexToHash("0xdddd")
+		api.applyTopics(c, [][]common.Hash{{}, {topic1}})
+		assert.Nil(t, c.Topics[0])
+		assert.NotNil(t, c.Topics[1])
+	})
+
+	t.Run("more than 5 topics truncated", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		topics := make([][]common.Hash, 7)
+		for i := range topics {
+			topics[i] = []common.Hash{common.HexToHash("0x01")}
+		}
+		api.applyTopics(c, topics)
+		// Only first 5 should be set
+		for i := 0; i < 5; i++ {
+			assert.NotNil(t, c.Topics[i])
+		}
+	})
+
+	t.Run("multiple hashes in topic uses first", func(t *testing.T) {
+		c := &logdb.EventCriteria{}
+		h1 := common.HexToHash("0x1111")
+		h2 := common.HexToHash("0x2222")
+		api.applyTopics(c, [][]common.Hash{{h1, h2}})
+		assert.NotNil(t, c.Topics[0])
+		assert.Equal(t, meter.Bytes32(h1), *c.Topics[0])
+	})
+}
+
+// ---------- blockNumberToUint32 tests (needs chain mock, test parsing only) ----------
+
+func TestBlockNumberToUint32_Parsing(t *testing.T) {
+	// We test the format parsing logic through the public method signature expectations.
+	// The "earliest" case returns 0 and doesn't need chain.
+	// Other cases need chain, so we only test format validation here.
+
+	// Test that hexUint64 parsing would work for valid inputs
+	n, err := hexutil.DecodeUint64("0x10")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(16), n)
+
+	n, err = hexutil.DecodeUint64("0x0")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), n)
+
+	_, err = hexutil.DecodeUint64("invalid")
+	assert.Error(t, err)
+
+	_, err = hexutil.DecodeUint64("latest")
+	assert.Error(t, err)
+}
+
+// ---------- CallArgs JSON marshaling ----------
+
+func TestCallArgs_JSONUnmarshal(t *testing.T) {
+	jsonStr := `{
+		"from": "0x0000000000000000000000000000000000000001",
+		"to": "0x0000000000000000000000000000000000000002",
+		"gas": "0x5208",
+		"gasPrice": "0x174876e800",
+		"value": "0x3e8",
+		"data": "0xabcd"
+	}`
+
+	var args CallArgs
+	err := json.Unmarshal([]byte(jsonStr), &args)
+	assert.NoError(t, err)
+	assert.NotNil(t, args.From)
+	assert.NotNil(t, args.To)
+	assert.NotNil(t, args.Gas)
+	assert.Equal(t, uint64(21000), args.gasLimit())
+	assert.NotNil(t, args.GasPrice)
+	assert.NotNil(t, args.Value)
+	assert.NotNil(t, args.Data)
+	assert.Equal(t, []byte{0xab, 0xcd}, args.dataBytes())
+}
+
+func TestCallArgs_JSONUnmarshal_Minimal(t *testing.T) {
+	jsonStr := `{}`
+	var args CallArgs
+	err := json.Unmarshal([]byte(jsonStr), &args)
+	assert.NoError(t, err)
+	assert.Nil(t, args.From)
+	assert.Nil(t, args.To)
+	assert.Nil(t, args.Gas)
+	assert.Equal(t, uint64(0), args.gasLimit())
+	assert.Nil(t, args.dataBytes())
+}
+
+func TestCallArgs_JSONUnmarshal_InputOverridesData(t *testing.T) {
+	jsonStr := `{
+		"data": "0x1111",
+		"input": "0x2222"
+	}`
+	var args CallArgs
+	err := json.Unmarshal([]byte(jsonStr), &args)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x22, 0x22}, args.dataBytes())
+}

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/meterio/meter-pov/logdb"
 	"github.com/meterio/meter-pov/meter"
 	"github.com/stretchr/testify/assert"
 )
@@ -200,69 +199,70 @@ func TestEthAPI_GetFilterChanges_NotFound(t *testing.T) {
 	assert.Equal(t, []string{}, hashes)
 }
 
-// ---------- applyTopics tests ----------
+// ---------- buildCriteriaSet tests ----------
 
-func TestApplyTopics(t *testing.T) {
-	api := &EthAPI{}
-
-	t.Run("empty topics", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
-		api.applyTopics(c, nil)
-		for _, topic := range c.Topics {
+func TestBuildCriteriaSet(t *testing.T) {
+	t.Run("no addresses no topics", func(t *testing.T) {
+		cs := buildCriteriaSet(nil, nil)
+		assert.Equal(t, 1, len(cs))
+		assert.Nil(t, cs[0].Address)
+		for _, topic := range cs[0].Topics {
 			assert.Nil(t, topic)
 		}
 	})
 
-	t.Run("single topic", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
-		topicHash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
-		api.applyTopics(c, [][]common.Hash{{topicHash}})
-		assert.NotNil(t, c.Topics[0])
-		assert.Equal(t, meter.Bytes32(topicHash), *c.Topics[0])
-		assert.Nil(t, c.Topics[1])
+	t.Run("single address no topics", func(t *testing.T) {
+		addr := common.HexToAddress("0xdeadbeef")
+		cs := buildCriteriaSet([]common.Address{addr}, nil)
+		assert.Equal(t, 1, len(cs))
+		assert.NotNil(t, cs[0].Address)
 	})
 
-	t.Run("multiple topics", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
-		topic0 := common.HexToHash("0xaaaa")
-		topic1 := common.HexToHash("0xbbbb")
-		topic2 := common.HexToHash("0xcccc")
-		api.applyTopics(c, [][]common.Hash{{topic0}, {topic1}, {topic2}})
-		assert.NotNil(t, c.Topics[0])
-		assert.NotNil(t, c.Topics[1])
-		assert.NotNil(t, c.Topics[2])
-		assert.Nil(t, c.Topics[3])
-		assert.Nil(t, c.Topics[4])
+	t.Run("single topic exact match", func(t *testing.T) {
+		h := common.HexToHash("0x1234")
+		cs := buildCriteriaSet(nil, [][]common.Hash{{h}})
+		assert.Equal(t, 1, len(cs))
+		assert.NotNil(t, cs[0].Topics[0])
+		assert.Equal(t, meter.Bytes32(h), *cs[0].Topics[0])
 	})
 
-	t.Run("empty topic list skipped", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
-		topic1 := common.HexToHash("0xdddd")
-		api.applyTopics(c, [][]common.Hash{{}, {topic1}})
-		assert.Nil(t, c.Topics[0])
-		assert.NotNil(t, c.Topics[1])
+	t.Run("OR topics expand into multiple criteria", func(t *testing.T) {
+		h1 := common.HexToHash("0x1111")
+		h2 := common.HexToHash("0x2222")
+		cs := buildCriteriaSet(nil, [][]common.Hash{{h1, h2}})
+		assert.Equal(t, 2, len(cs))
+		assert.Equal(t, meter.Bytes32(h1), *cs[0].Topics[0])
+		assert.Equal(t, meter.Bytes32(h2), *cs[1].Topics[0])
 	})
 
-	t.Run("more than 5 topics truncated", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
+	t.Run("two addresses times two OR topics", func(t *testing.T) {
+		a1 := common.HexToAddress("0x1111")
+		a2 := common.HexToAddress("0x2222")
+		h1 := common.HexToHash("0xaaaa")
+		h2 := common.HexToHash("0xbbbb")
+		cs := buildCriteriaSet([]common.Address{a1, a2}, [][]common.Hash{{h1, h2}})
+		// 2 addresses × 2 topic OR values = 4 criteria
+		assert.Equal(t, 4, len(cs))
+	})
+
+	t.Run("empty topic slot means match any", func(t *testing.T) {
+		h1 := common.HexToHash("0xdddd")
+		cs := buildCriteriaSet(nil, [][]common.Hash{{}, {h1}})
+		assert.Equal(t, 1, len(cs))
+		assert.Nil(t, cs[0].Topics[0])
+		assert.NotNil(t, cs[0].Topics[1])
+	})
+
+	t.Run("more than 5 topic positions truncated", func(t *testing.T) {
 		topics := make([][]common.Hash, 7)
 		for i := range topics {
 			topics[i] = []common.Hash{common.HexToHash("0x01")}
 		}
-		api.applyTopics(c, topics)
-		// Only first 5 should be set
+		cs := buildCriteriaSet(nil, topics)
+		assert.Equal(t, 1, len(cs))
 		for i := 0; i < 5; i++ {
-			assert.NotNil(t, c.Topics[i])
+			assert.NotNil(t, cs[0].Topics[i])
 		}
-	})
-
-	t.Run("multiple hashes in topic uses first", func(t *testing.T) {
-		c := &logdb.EventCriteria{}
-		h1 := common.HexToHash("0x1111")
-		h2 := common.HexToHash("0x2222")
-		api.applyTopics(c, [][]common.Hash{{h1, h2}})
-		assert.NotNil(t, c.Topics[0])
-		assert.Equal(t, meter.Bytes32(h1), *c.Topics[0])
 	})
 }
 

--- a/api/ethapi/convert.go
+++ b/api/ethapi/convert.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2020 The Meter.io developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package ethapi
+
+import (
+	"encoding/hex"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/tx"
+)
+
+var (
+	emptyUnclesHash = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+	zeroHash        = "0x0000000000000000000000000000000000000000000000000000000000000000"
+	zeroBloom       = "0x" + hex.EncodeToString(make([]byte, 256))
+	zeroNonce       = "0x0000000000000000"
+)
+
+func hexUint64(n uint64) string {
+	return hexutil.EncodeUint64(n)
+}
+
+func hexBig(b *big.Int) string {
+	return hexutil.EncodeBig(b)
+}
+
+func meterBlockToEthBlock(blk *block.Block, receipts tx.Receipts, expanded bool, chainID *big.Int, baseGasPrice *big.Int) map[string]interface{} {
+	header := blk.Header()
+	signer, _ := header.Signer()
+
+	result := map[string]interface{}{
+		"hash":             header.ID().String(),
+		"parentHash":       header.ParentID().String(),
+		"number":           hexUint64(uint64(header.Number())),
+		"timestamp":        hexUint64(header.Timestamp()),
+		"gasLimit":         hexUint64(header.GasLimit()),
+		"gasUsed":          hexUint64(header.GasUsed()),
+		"miner":            signer.String(),
+		"totalDifficulty":  hexUint64(header.TotalScore()),
+		"transactionsRoot": header.TxsRoot().String(),
+		"stateRoot":        header.StateRoot().String(),
+		"receiptsRoot":     header.ReceiptsRoot().String(),
+		"size":             hexUint64(uint64(blk.Size())),
+		"nonce":            zeroNonce,
+		"mixHash":          zeroHash,
+		"sha3Uncles":       emptyUnclesHash,
+		"logsBloom":        zeroBloom,
+		"extraData":        "0x",
+		"difficulty":       "0x0",
+		"uncles":           []string{},
+		"baseFeePerGas":    "0x0",
+	}
+
+	if expanded {
+		txs := make([]interface{}, 0, len(blk.Txs))
+		for i, t := range blk.Txs {
+			meta := &chain.TxMeta{
+				BlockID: header.ID(),
+				Index:   uint64(i),
+			}
+			var receipt *tx.Receipt
+			if i < len(receipts) {
+				receipt = receipts[i]
+			}
+			txObj := meterTxToEthTx(t, meta, header, chainID, baseGasPrice, receipt)
+			txs = append(txs, txObj)
+		}
+		result["transactions"] = txs
+	} else {
+		txHashes := make([]string, 0, len(blk.Txs))
+		for _, t := range blk.Txs {
+			txHashes = append(txHashes, t.ID().String())
+		}
+		result["transactions"] = txHashes
+	}
+
+	return result
+}
+
+func meterTxToEthTx(t *tx.Transaction, meta *chain.TxMeta, header *block.Header, chainID *big.Int, baseGasPrice *big.Int, receipt *tx.Receipt) map[string]interface{} {
+	origin, _ := t.Signer()
+	clauses := t.Clauses()
+
+	var to interface{}
+	value := "0x0"
+	input := "0x"
+
+	if len(clauses) > 0 {
+		c := clauses[0]
+		if c.To() != nil {
+			to = c.To().String()
+		}
+		if c.Value() != nil {
+			value = hexBig(c.Value())
+		}
+		if len(c.Data()) > 0 {
+			input = hexutil.Encode(c.Data())
+		}
+	}
+
+	gasPrice := t.GasPrice(baseGasPrice)
+
+	v := big.NewInt(0)
+	r := big.NewInt(0)
+	s := big.NewInt(0)
+	txType := "0x0"
+
+	if t.IsEthTx() {
+		ethTx, err := t.GetEthTx()
+		if err == nil {
+			v, r, s = ethTx.RawSignatureValues()
+			if ethTx.Type() == 2 {
+				txType = "0x2"
+			} else if ethTx.Type() == 1 {
+				txType = "0x1"
+			}
+		}
+	} else {
+		sig := t.Signature()
+		if len(sig) >= 65 {
+			r.SetBytes(sig[:32])
+			s.SetBytes(sig[32:64])
+			v.SetBytes(sig[64:65])
+		}
+	}
+
+	result := map[string]interface{}{
+		"hash":                 t.ID().String(),
+		"blockHash":            header.ID().String(),
+		"blockNumber":          hexUint64(uint64(header.Number())),
+		"transactionIndex":     hexUint64(meta.Index),
+		"from":                 origin.String(),
+		"to":                   to,
+		"value":                value,
+		"input":                input,
+		"gas":                  hexUint64(t.Gas()),
+		"gasPrice":             hexBig(gasPrice),
+		"nonce":                hexUint64(t.Nonce()),
+		"v":                    hexBig(v),
+		"r":                    hexBig(r),
+		"s":                    hexBig(s),
+		"type":                 txType,
+		"chainId":              hexBig(chainID),
+		"maxPriorityFeePerGas": "0x0",
+		"maxFeePerGas":         hexBig(gasPrice),
+	}
+
+	return result
+}
+
+func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chain.TxMeta, header *block.Header, chainID *big.Int, baseGasPrice *big.Int) map[string]interface{} {
+	origin, _ := t.Signer()
+	clauses := t.Clauses()
+
+	var to interface{}
+	if len(clauses) > 0 && clauses[0].To() != nil {
+		to = clauses[0].To().String()
+	}
+
+	status := "0x1"
+	if receipt.Reverted {
+		status = "0x0"
+	}
+
+	logs := make([]interface{}, 0)
+	logIndex := 0
+	for _, output := range receipt.Outputs {
+		for _, event := range output.Events {
+			logs = append(logs, meterLogToEthLog(event, header, t, meta, logIndex))
+			logIndex++
+		}
+	}
+
+	gasPrice := t.GasPrice(baseGasPrice)
+
+	var contractAddress interface{}
+	if len(clauses) > 0 && clauses[0].To() == nil {
+		nonce := t.Nonce()
+		addr := meter.Address(meter.EthCreateContractAddress(common.Address(origin), uint32(nonce)))
+		contractAddress = addr.String()
+	}
+
+	result := map[string]interface{}{
+		"transactionHash":   t.ID().String(),
+		"transactionIndex":  hexUint64(meta.Index),
+		"blockHash":         header.ID().String(),
+		"blockNumber":       hexUint64(uint64(header.Number())),
+		"from":              origin.String(),
+		"to":                to,
+		"gasUsed":           hexUint64(receipt.GasUsed),
+		"cumulativeGasUsed": hexUint64(receipt.GasUsed),
+		"contractAddress":   contractAddress,
+		"logs":              logs,
+		"logsBloom":         zeroBloom,
+		"status":            status,
+		"type":              "0x0",
+		"effectiveGasPrice": hexBig(gasPrice),
+	}
+
+	return result
+}
+
+func meterLogToEthLog(event *tx.Event, header *block.Header, t *tx.Transaction, meta *chain.TxMeta, logIndex int) map[string]interface{} {
+	topics := make([]string, 0, len(event.Topics))
+	for _, topic := range event.Topics {
+		topics = append(topics, topic.String())
+	}
+
+	return map[string]interface{}{
+		"address":          event.Address.String(),
+		"topics":           topics,
+		"data":             hexutil.Encode(event.Data),
+		"blockHash":        header.ID().String(),
+		"blockNumber":      hexUint64(uint64(header.Number())),
+		"transactionHash":  t.ID().String(),
+		"transactionIndex": hexUint64(meta.Index),
+		"logIndex":         hexUint64(uint64(logIndex)),
+		"removed":          false,
+	}
+}

--- a/api/ethapi/convert.go
+++ b/api/ethapi/convert.go
@@ -56,7 +56,7 @@ func meterBlockToEthBlock(blk *block.Block, receipts tx.Receipts, expanded bool,
 		"extraData":        "0x",
 		"difficulty":       "0x0",
 		"uncles":           []string{},
-		"baseFeePerGas":    "0x0",
+		"baseFeePerGas":    hexBig(baseGasPrice),
 	}
 
 	if expanded {
@@ -156,7 +156,7 @@ func meterTxToEthTx(t *tx.Transaction, meta *chain.TxMeta, header *block.Header,
 	return result
 }
 
-func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chain.TxMeta, header *block.Header, chainID *big.Int, baseGasPrice *big.Int) map[string]interface{} {
+func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chain.TxMeta, header *block.Header, chainID *big.Int, baseGasPrice *big.Int, cumulativeGasUsed uint64) map[string]interface{} {
 	origin, _ := t.Signer()
 	clauses := t.Clauses()
 
@@ -196,7 +196,7 @@ func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chai
 		"from":              origin.String(),
 		"to":                to,
 		"gasUsed":           hexUint64(receipt.GasUsed),
-		"cumulativeGasUsed": hexUint64(receipt.GasUsed),
+		"cumulativeGasUsed": hexUint64(cumulativeGasUsed),
 		"contractAddress":   contractAddress,
 		"logs":              logs,
 		"logsBloom":         zeroBloom,

--- a/api/ethapi/convert.go
+++ b/api/ethapi/convert.go
@@ -188,6 +188,18 @@ func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chai
 		contractAddress = addr.String()
 	}
 
+	txType := "0x0"
+	if t.IsEthTx() {
+		if ethTx, err := t.GetEthTx(); err == nil {
+			switch ethTx.Type() {
+			case 2:
+				txType = "0x2"
+			case 1:
+				txType = "0x1"
+			}
+		}
+	}
+
 	result := map[string]interface{}{
 		"transactionHash":   t.ID().String(),
 		"transactionIndex":  hexUint64(meta.Index),
@@ -201,7 +213,7 @@ func meterReceiptToEthReceipt(receipt *tx.Receipt, t *tx.Transaction, meta *chai
 		"logs":              logs,
 		"logsBloom":         zeroBloom,
 		"status":            status,
-		"type":              "0x0",
+		"type":              txType,
 		"effectiveGasPrice": hexBig(gasPrice),
 	}
 

--- a/api/ethapi/convert_test.go
+++ b/api/ethapi/convert_test.go
@@ -268,7 +268,7 @@ func TestMeterReceiptToEthReceipt_Success(t *testing.T) {
 		},
 	}
 
-	result := meterReceiptToEthReceipt(receipt, trx, meta, header, chainID, baseGasPrice)
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, chainID, baseGasPrice, receipt.GasUsed)
 
 	assert.Equal(t, trx.ID().String(), result["transactionHash"])
 	assert.Equal(t, header.ID().String(), result["blockHash"])
@@ -308,7 +308,7 @@ func TestMeterReceiptToEthReceipt_Reverted(t *testing.T) {
 		Outputs:  []*tx.Output{},
 	}
 
-	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0), receipt.GasUsed)
 	assert.Equal(t, "0x0", result["status"]) // reverted
 }
 
@@ -327,7 +327,7 @@ func TestMeterReceiptToEthReceipt_ContractCreation(t *testing.T) {
 		Outputs:  []*tx.Output{},
 	}
 
-	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0), receipt.GasUsed)
 
 	// Contract creation should produce a contract address
 	assert.NotNil(t, result["contractAddress"])
@@ -368,7 +368,7 @@ func TestMeterReceiptToEthReceipt_MultipleEventsAcrossOutputs(t *testing.T) {
 		},
 	}
 
-	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0), receipt.GasUsed)
 
 	logs, ok := result["logs"].([]interface{})
 	assert.True(t, ok)

--- a/api/ethapi/convert_test.go
+++ b/api/ethapi/convert_test.go
@@ -1,0 +1,443 @@
+package ethapi
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/tx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHexUint64(t *testing.T) {
+	assert.Equal(t, "0x0", hexUint64(0))
+	assert.Equal(t, "0x1", hexUint64(1))
+	assert.Equal(t, "0xff", hexUint64(255))
+	assert.Equal(t, "0x100", hexUint64(256))
+	assert.Equal(t, "0xffffffffffffffff", hexUint64(^uint64(0)))
+}
+
+func TestHexBig(t *testing.T) {
+	assert.Equal(t, "0x0", hexBig(big.NewInt(0)))
+	assert.Equal(t, "0x1", hexBig(big.NewInt(1)))
+	assert.Equal(t, "0xa", hexBig(big.NewInt(10)))
+	assert.Equal(t, "0x64", hexBig(big.NewInt(100)))
+
+	large := new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil)
+	result := hexBig(large)
+	assert.NotEmpty(t, result)
+	assert.Equal(t, "0x", result[:2])
+}
+
+func buildTestBlock(txs ...*tx.Transaction) *block.Block {
+	builder := new(block.Builder).
+		Timestamp(1000000).
+		GasLimit(10000000).
+		GasUsed(21000).
+		TotalScore(100).
+		Beneficiary(meter.BytesToAddress([]byte("beneficiary")))
+
+	for _, t := range txs {
+		builder = builder.Transaction(t)
+	}
+	return builder.Build()
+}
+
+func buildSignedTestTx() *tx.Transaction {
+	toAddr := meter.BytesToAddress([]byte("recipient"))
+	clause := tx.NewClause(&toAddr).
+		WithValue(big.NewInt(1000)).
+		WithData([]byte{0xab, 0xcd})
+
+	trx := new(tx.Builder).
+		ChainTag(82).
+		Gas(21000).
+		GasPriceCoef(0).
+		Nonce(12345).
+		Expiration(720).
+		Clause(clause).
+		Build()
+
+	key, _ := crypto.GenerateKey()
+	sig, _ := crypto.Sign(trx.SigningHash().Bytes(), key)
+	return trx.WithSignature(sig)
+}
+
+func buildContractCreationTx() *tx.Transaction {
+	clause := tx.NewClause(nil).
+		WithValue(big.NewInt(0)).
+		WithData([]byte{0x60, 0x60, 0x60, 0x40})
+
+	trx := new(tx.Builder).
+		ChainTag(82).
+		Gas(100000).
+		GasPriceCoef(0).
+		Nonce(99).
+		Expiration(720).
+		Clause(clause).
+		Build()
+
+	key, _ := crypto.GenerateKey()
+	sig, _ := crypto.Sign(trx.SigningHash().Bytes(), key)
+	return trx.WithSignature(sig)
+}
+
+func TestMeterBlockToEthBlock_CollapsedTxs(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+
+	result := meterBlockToEthBlock(blk, nil, false, chainID, baseGasPrice)
+
+	// Check required Ethereum block fields
+	assert.Equal(t, blk.Header().ID().String(), result["hash"])
+	assert.Equal(t, blk.Header().ParentID().String(), result["parentHash"])
+	assert.Equal(t, hexUint64(uint64(blk.Header().Number())), result["number"])
+	assert.Equal(t, hexUint64(blk.Header().Timestamp()), result["timestamp"])
+	assert.Equal(t, hexUint64(blk.Header().GasLimit()), result["gasLimit"])
+	assert.Equal(t, hexUint64(blk.Header().GasUsed()), result["gasUsed"])
+	assert.Equal(t, hexUint64(blk.Header().TotalScore()), result["totalDifficulty"])
+
+	// Fake ETH fields
+	assert.Equal(t, zeroNonce, result["nonce"])
+	assert.Equal(t, zeroHash, result["mixHash"])
+	assert.Equal(t, emptyUnclesHash, result["sha3Uncles"])
+	assert.Equal(t, zeroBloom, result["logsBloom"])
+	assert.Equal(t, "0x", result["extraData"])
+	assert.Equal(t, "0x0", result["difficulty"])
+	assert.Equal(t, "0x0", result["baseFeePerGas"])
+	assert.Equal(t, []string{}, result["uncles"])
+
+	// Collapsed transactions - should be a list of hashes
+	txHashes, ok := result["transactions"].([]string)
+	assert.True(t, ok, "transactions should be []string for collapsed mode")
+	assert.Equal(t, 1, len(txHashes))
+	assert.Equal(t, trx.ID().String(), txHashes[0])
+}
+
+func TestMeterBlockToEthBlock_ExpandedTxs(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+
+	receipt := &tx.Receipt{
+		GasUsed:  21000,
+		GasPayer: meter.BytesToAddress([]byte("payer")),
+		Paid:     big.NewInt(100),
+		Reward:   big.NewInt(10),
+		Reverted: false,
+		Outputs: []*tx.Output{
+			{Events: tx.Events{}, Transfers: tx.Transfers{}},
+		},
+	}
+	receipts := tx.Receipts{receipt}
+
+	result := meterBlockToEthBlock(blk, receipts, true, chainID, baseGasPrice)
+
+	txs, ok := result["transactions"].([]interface{})
+	assert.True(t, ok, "transactions should be []interface{} for expanded mode")
+	assert.Equal(t, 1, len(txs))
+
+	txObj, ok := txs[0].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, trx.ID().String(), txObj["hash"])
+	assert.Equal(t, hexUint64(0), txObj["transactionIndex"])
+}
+
+func TestMeterBlockToEthBlock_EmptyBlock(t *testing.T) {
+	blk := buildTestBlock()
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+
+	result := meterBlockToEthBlock(blk, nil, false, chainID, baseGasPrice)
+	txHashes, ok := result["transactions"].([]string)
+	assert.True(t, ok)
+	assert.Equal(t, 0, len(txHashes))
+}
+
+func TestMeterTxToEthTx(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+	meta := &chain.TxMeta{
+		BlockID: header.ID(),
+		Index:   0,
+	}
+
+	result := meterTxToEthTx(trx, meta, header, chainID, baseGasPrice, nil)
+
+	assert.Equal(t, trx.ID().String(), result["hash"])
+	assert.Equal(t, header.ID().String(), result["blockHash"])
+	assert.Equal(t, hexUint64(uint64(header.Number())), result["blockNumber"])
+	assert.Equal(t, hexUint64(0), result["transactionIndex"])
+	assert.Equal(t, hexUint64(21000), result["gas"])
+	assert.Equal(t, hexUint64(12345), result["nonce"])
+	assert.Equal(t, "0x0", result["type"])
+	assert.Equal(t, hexBig(chainID), result["chainId"])
+	assert.Equal(t, "0x0", result["maxPriorityFeePerGas"])
+
+	// Check to address is set
+	assert.NotNil(t, result["to"])
+
+	// Check from is set
+	from, ok := result["from"].(string)
+	assert.True(t, ok)
+	assert.NotEmpty(t, from)
+
+	// Check value and input are set
+	assert.NotEmpty(t, result["value"])
+	assert.NotEmpty(t, result["input"])
+
+	// Check signature fields exist
+	assert.NotNil(t, result["v"])
+	assert.NotNil(t, result["r"])
+	assert.NotNil(t, result["s"])
+}
+
+func TestMeterTxToEthTx_ContractCreation(t *testing.T) {
+	trx := buildContractCreationTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	result := meterTxToEthTx(trx, meta, header, chainID, baseGasPrice, nil)
+
+	// For contract creation, "to" should be nil
+	assert.Nil(t, result["to"])
+	assert.NotEmpty(t, result["input"])
+}
+
+func TestMeterTxToEthTx_NoClauses(t *testing.T) {
+	// Transaction with no clauses
+	trx := new(tx.Builder).
+		ChainTag(82).
+		Gas(21000).
+		Nonce(1).
+		Build()
+	key, _ := crypto.GenerateKey()
+	sig, _ := crypto.Sign(trx.SigningHash().Bytes(), key)
+	trx = trx.WithSignature(sig)
+
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	result := meterTxToEthTx(trx, meta, header, big.NewInt(82), big.NewInt(0), nil)
+
+	// With no clauses, to should be nil, value should be "0x0", input should be "0x"
+	assert.Nil(t, result["to"])
+	assert.Equal(t, "0x0", result["value"])
+	assert.Equal(t, "0x", result["input"])
+}
+
+func TestMeterReceiptToEthReceipt_Success(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	chainID := big.NewInt(82)
+	baseGasPrice := big.NewInt(500000000000)
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	topic1 := meter.BytesToBytes32([]byte("Transfer(address,address,uint256)"))
+	receipt := &tx.Receipt{
+		GasUsed:  21000,
+		GasPayer: meter.BytesToAddress([]byte("payer")),
+		Paid:     big.NewInt(100),
+		Reward:   big.NewInt(10),
+		Reverted: false,
+		Outputs: []*tx.Output{
+			{
+				Events: tx.Events{
+					&tx.Event{
+						Address: meter.BytesToAddress([]byte("contract")),
+						Topics:  []meter.Bytes32{topic1},
+						Data:    []byte{0x01, 0x02, 0x03},
+					},
+				},
+				Transfers: tx.Transfers{},
+			},
+		},
+	}
+
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, chainID, baseGasPrice)
+
+	assert.Equal(t, trx.ID().String(), result["transactionHash"])
+	assert.Equal(t, header.ID().String(), result["blockHash"])
+	assert.Equal(t, hexUint64(uint64(header.Number())), result["blockNumber"])
+	assert.Equal(t, hexUint64(0), result["transactionIndex"])
+	assert.Equal(t, hexUint64(21000), result["gasUsed"])
+	assert.Equal(t, hexUint64(21000), result["cumulativeGasUsed"])
+	assert.Equal(t, "0x1", result["status"]) // success
+	assert.Equal(t, "0x0", result["type"])
+	assert.Equal(t, zeroBloom, result["logsBloom"])
+	assert.Nil(t, result["contractAddress"]) // not a contract creation
+
+	// Check logs
+	logs, ok := result["logs"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(logs))
+
+	log, ok := logs[0].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, meter.BytesToAddress([]byte("contract")).String(), log["address"])
+	assert.Equal(t, hexUint64(0), log["logIndex"])
+	assert.Equal(t, false, log["removed"])
+}
+
+func TestMeterReceiptToEthReceipt_Reverted(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	receipt := &tx.Receipt{
+		GasUsed:  21000,
+		GasPayer: meter.BytesToAddress([]byte("payer")),
+		Paid:     big.NewInt(100),
+		Reward:   big.NewInt(10),
+		Reverted: true,
+		Outputs:  []*tx.Output{},
+	}
+
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+	assert.Equal(t, "0x0", result["status"]) // reverted
+}
+
+func TestMeterReceiptToEthReceipt_ContractCreation(t *testing.T) {
+	trx := buildContractCreationTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	receipt := &tx.Receipt{
+		GasUsed:  50000,
+		GasPayer: meter.BytesToAddress([]byte("payer")),
+		Paid:     big.NewInt(100),
+		Reward:   big.NewInt(10),
+		Reverted: false,
+		Outputs:  []*tx.Output{},
+	}
+
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+
+	// Contract creation should produce a contract address
+	assert.NotNil(t, result["contractAddress"])
+	addr, ok := result["contractAddress"].(string)
+	assert.True(t, ok)
+	assert.NotEmpty(t, addr)
+	assert.Nil(t, result["to"]) // to is nil for contract creation
+}
+
+func TestMeterReceiptToEthReceipt_MultipleEventsAcrossOutputs(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 2}
+
+	topic1 := meter.BytesToBytes32([]byte("event1"))
+	topic2 := meter.BytesToBytes32([]byte("event2"))
+	topic3 := meter.BytesToBytes32([]byte("event3"))
+
+	receipt := &tx.Receipt{
+		GasUsed:  42000,
+		GasPayer: meter.BytesToAddress([]byte("payer")),
+		Paid:     big.NewInt(100),
+		Reward:   big.NewInt(10),
+		Reverted: false,
+		Outputs: []*tx.Output{
+			{
+				Events: tx.Events{
+					&tx.Event{Address: meter.BytesToAddress([]byte("c1")), Topics: []meter.Bytes32{topic1}, Data: []byte{0x01}},
+					&tx.Event{Address: meter.BytesToAddress([]byte("c2")), Topics: []meter.Bytes32{topic2}, Data: []byte{0x02}},
+				},
+			},
+			{
+				Events: tx.Events{
+					&tx.Event{Address: meter.BytesToAddress([]byte("c3")), Topics: []meter.Bytes32{topic3}, Data: []byte{0x03}},
+				},
+			},
+		},
+	}
+
+	result := meterReceiptToEthReceipt(receipt, trx, meta, header, big.NewInt(82), big.NewInt(0))
+
+	logs, ok := result["logs"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 3, len(logs))
+
+	// Verify log indices are sequential
+	for i, l := range logs {
+		logMap := l.(map[string]interface{})
+		assert.Equal(t, hexUint64(uint64(i)), logMap["logIndex"])
+		assert.Equal(t, hexUint64(2), logMap["transactionIndex"])
+	}
+}
+
+func TestMeterLogToEthLog(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 3}
+
+	topic1 := meter.BytesToBytes32([]byte("Transfer(address,address,uint256)"))
+	topic2 := meter.BytesToBytes32([]byte("from_address"))
+	event := &tx.Event{
+		Address: meter.BytesToAddress([]byte("contractAddr")),
+		Topics:  []meter.Bytes32{topic1, topic2},
+		Data:    []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	result := meterLogToEthLog(event, header, trx, meta, 7)
+
+	assert.Equal(t, event.Address.String(), result["address"])
+	assert.Equal(t, header.ID().String(), result["blockHash"])
+	assert.Equal(t, hexUint64(uint64(header.Number())), result["blockNumber"])
+	assert.Equal(t, trx.ID().String(), result["transactionHash"])
+	assert.Equal(t, hexUint64(3), result["transactionIndex"])
+	assert.Equal(t, hexUint64(7), result["logIndex"])
+	assert.Equal(t, false, result["removed"])
+
+	topics, ok := result["topics"].([]string)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(topics))
+	assert.Equal(t, topic1.String(), topics[0])
+	assert.Equal(t, topic2.String(), topics[1])
+
+	assert.Equal(t, "0xdeadbeef", result["data"])
+}
+
+func TestMeterLogToEthLog_NoTopics(t *testing.T) {
+	trx := buildSignedTestTx()
+	blk := buildTestBlock(trx)
+	header := blk.Header()
+	meta := &chain.TxMeta{BlockID: header.ID(), Index: 0}
+
+	event := &tx.Event{
+		Address: meter.BytesToAddress([]byte("contract")),
+		Topics:  []meter.Bytes32{},
+		Data:    []byte{},
+	}
+
+	result := meterLogToEthLog(event, header, trx, meta, 0)
+	topics, ok := result["topics"].([]string)
+	assert.True(t, ok)
+	assert.Equal(t, 0, len(topics))
+}
+
+func TestConstants(t *testing.T) {
+	// Verify constant values match Ethereum expectations
+	assert.Equal(t, "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", emptyUnclesHash)
+	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", zeroHash)
+	assert.Equal(t, "0x0000000000000000", zeroNonce)
+	assert.Equal(t, 514, len(zeroBloom)) // "0x" + 512 hex chars
+	assert.Equal(t, "0x", zeroBloom[:2])
+}

--- a/api/ethapi/server.go
+++ b/api/ethapi/server.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 The Meter.io developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package ethapi
+
+import (
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/co"
+	"github.com/meterio/meter-pov/logdb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/state"
+	"github.com/meterio/meter-pov/txpool"
+)
+
+func getChainID() *big.Int {
+	if meter.IsMainNet() {
+		return big.NewInt(meter.MainnetChainID)
+	}
+	return big.NewInt(meter.TestnetChainID)
+}
+
+func StartEthRPC(
+	chain *chain.Chain,
+	stateCreator *state.Creator,
+	txPool *txpool.TxPool,
+	logDB *logdb.LogDB,
+	callGasLimit uint64,
+	addr string,
+) (string, func()) {
+	chainID := getChainID()
+	server := rpc.NewServer()
+
+	ethAPI := NewEthAPI(chain, stateCreator, txPool, logDB, chainID, callGasLimit)
+	if err := server.RegisterName("eth", ethAPI); err != nil {
+		panic(fmt.Sprintf("register eth namespace: %v", err))
+	}
+	if err := server.RegisterName("net", &NetAPI{chainID: chainID}); err != nil {
+		panic(fmt.Sprintf("register net namespace: %v", err))
+	}
+	if err := server.RegisterName("web3", &Web3API{}); err != nil {
+		panic(fmt.Sprintf("register web3 namespace: %v", err))
+	}
+	if err := server.RegisterName("rpc", &RPCAPI{}); err != nil {
+		panic(fmt.Sprintf("register rpc namespace: %v", err))
+	}
+	if err := server.RegisterName("evm", &EVMAPI{}); err != nil {
+		panic(fmt.Sprintf("register evm namespace: %v", err))
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		panic(fmt.Sprintf("listen eth-rpc addr [%v]: %v", addr, err))
+	}
+
+	handler := server.WebsocketHandler([]string{"*"})
+	mux := http.NewServeMux()
+	mux.Handle("/ws", handler)
+	mux.Handle("/", newCORSHandler(server))
+
+	srv := &http.Server{
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	var goes co.Goes
+	goes.Go(func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			slog.Warn("eth-rpc server stopped", "err", err)
+		}
+	})
+
+	slog.Info("ETH JSON-RPC server started", "addr", listener.Addr().String())
+
+	return "http://" + listener.Addr().String() + "/", func() {
+		server.Stop()
+		if err := srv.Close(); err != nil {
+			slog.Warn("could not close eth-rpc server", "err", err)
+		}
+		goes.Wait()
+	}
+}
+
+func newCORSHandler(srv *rpc.Server) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		srv.ServeHTTP(w, r)
+	})
+}

--- a/api/ethapi/server.go
+++ b/api/ethapi/server.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -68,10 +69,21 @@ func StartEthRPC(
 		panic(fmt.Sprintf("listen eth-rpc addr [%v]: %v", addr, err))
 	}
 
-	handler := server.WebsocketHandler([]string{"*"})
+	wsHandler := server.WebsocketHandler([]string{"*"})
+	httpHandler := newCORSHandler(server)
+	// combined dispatches WebSocket upgrades to wsHandler, plain HTTP to httpHandler.
+	// This allows clients to connect via ws://host:port/ (MetaMask, ethers.js default)
+	// as well as ws://host:port/ws.
+	combined := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			wsHandler.ServeHTTP(w, r)
+		} else {
+			httpHandler.ServeHTTP(w, r)
+		}
+	})
 	mux := http.NewServeMux()
-	mux.Handle("/ws", handler)
-	mux.Handle("/", newCORSHandler(server))
+	mux.Handle("/ws", combined)
+	mux.Handle("/", combined)
 
 	srv := &http.Server{
 		Handler:      mux,

--- a/api/ethapi/server.go
+++ b/api/ethapi/server.go
@@ -56,6 +56,12 @@ func StartEthRPC(
 	if err := server.RegisterName("evm", &EVMAPI{}); err != nil {
 		panic(fmt.Sprintf("register evm namespace: %v", err))
 	}
+	if err := server.RegisterName("debug", &DebugAPI{}); err != nil {
+		panic(fmt.Sprintf("register debug namespace: %v", err))
+	}
+	if err := server.RegisterName("trace", &TraceAPI{}); err != nil {
+		panic(fmt.Sprintf("register trace namespace: %v", err))
+	}
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/api/ethapi/server_test.go
+++ b/api/ethapi/server_test.go
@@ -1,0 +1,67 @@
+package ethapi
+
+import (
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetChainID_Testnet(t *testing.T) {
+	// Initialize as testnet
+	meter.InitBlockChainConfig("test")
+	chainID := getChainID()
+	assert.Equal(t, big.NewInt(meter.TestnetChainID), chainID)
+}
+
+func TestGetChainID_Mainnet(t *testing.T) {
+	meter.InitBlockChainConfig("main")
+	chainID := getChainID()
+	assert.Equal(t, big.NewInt(meter.MainnetChainID), chainID)
+
+	// Reset to test so other tests aren't affected
+	meter.InitBlockChainConfig("test")
+}
+
+func TestNewCORSHandler_SetsHeaders(t *testing.T) {
+	srv := rpc.NewServer()
+	handler := newCORSHandler(srv)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "POST, GET, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type", w.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestNewCORSHandler_OptionsRequest(t *testing.T) {
+	srv := rpc.NewServer()
+	handler := newCORSHandler(srv)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	// Body should be empty for preflight
+	assert.Equal(t, 0, w.Body.Len())
+}
+
+func TestNewCORSHandler_GetRequest(t *testing.T) {
+	srv := rpc.NewServer()
+	handler := newCORSHandler(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// CORS headers should be set even for non-OPTIONS requests
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+}

--- a/cmd/meter/flags.go
+++ b/cmd/meter/flags.go
@@ -168,6 +168,11 @@ var (
 		Usage: "mblock count between epochs",
 		Value: 200,
 	}
+	ethRPCAddrFlag = cli.StringFlag{
+		Name:  "eth-rpc-addr",
+		Value: "localhost:8545",
+		Usage: "ETH JSON-RPC service listening address",
+	}
 	httpsCertFlag = cli.StringFlag{
 		Name:  "https-cert",
 		Usage: "path for https cert file (default is meterio.crt)",

--- a/cmd/meter/main.go
+++ b/cmd/meter/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/meterio/meter-pov/api"
+	"github.com/meterio/meter-pov/api/ethapi"
 	"github.com/meterio/meter-pov/api/doc"
 	"github.com/meterio/meter-pov/chain"
 	"github.com/meterio/meter-pov/cmd/meter/node"
@@ -135,6 +136,7 @@ func main() {
 			discoTopicFlag,
 			initCfgdDelegatesFlag,
 			epochBlockCountFlag,
+			ethRPCAddrFlag,
 			httpsCertFlag,
 			httpsKeyFlag,
 			enablePruningFlag,
@@ -396,6 +398,10 @@ func defaultAction(ctx *cli.Context) error {
 
 	apiURL, srvCloser := startAPIServer(ctx, apiHandler, chain.GenesisBlock().ID())
 	defer func() { slog.Info("stopping API server..."); srvCloser() }()
+
+	ethRPCURL, ethRPCCloser := ethapi.StartEthRPC(chain, stateCreator, txPool, logDB, uint64(ctx.Int(apiCallGasLimitFlag.Name)), ctx.String(ethRPCAddrFlag.Name))
+	defer func() { slog.Info("stopping ETH JSON-RPC server..."); ethRPCCloser() }()
+	slog.Info("ETH JSON-RPC", "url", ethRPCURL)
 
 	observeURL, observeSrvCloser := startObserveServer(ctx, reactor, pubkey, p2pcom.comm, chain, stateCreator)
 	defer func() { slog.Info("closing Observe Server ..."); observeSrvCloser() }()


### PR DESCRIPTION
## Summary

Port of #33 onto the `testnet` branch.

- Adds a native Go ETH JSON-RPC server inside meter-pov, eliminating the need for the Python meter-gear proxy
- Implements 33 RPC methods across `eth`, `net`, `web3`, `rpc`, and `evm` namespaces using geth's `rpc` package (already a dependency)
- New package `api/ethapi/` with server setup, method implementations, and Meter→Ethereum type conversion
- New CLI flag `--eth-rpc-addr` (default `localhost:8545`) to configure the listen address

### Methods implemented (Phase 1)

**Trivial/Static:** `eth_chainId`, `eth_gasPrice`, `eth_maxPriorityFeePerGas`, `eth_syncing`, `net_version`, `net_listening`, `net_peerCount`, `web3_clientVersion`, `rpc_modules`, `evm_snapshot`, `evm_revert`

**Simple:** `eth_blockNumber`, `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_newBlockFilter`, `eth_uninstallFilter`, `eth_getFilterChanges`

**Medium:** `eth_getBlockByNumber`, `eth_getBlockByHash`, `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getTransactionByBlockNumberAndIndex`, `eth_getTransactionByBlockHashAndIndex`, `eth_getBlockTransactionCountByNumber`, `eth_call`, `eth_estimateGas`, `eth_sendRawTransaction`, `eth_getLogs`

**Complex:** `eth_getBlockReceipts`, `eth_feeHistory`

## Test plan

- [ ] Send `eth_getBlockByNumber("latest", true)` and verify full block with expanded txs
- [ ] Send `eth_getTransactionReceipt(hash)` and verify log indices, status, gas
- [ ] Send `eth_getLogs` with multiple addresses and verify chunking produces correct results
- [ ] Send `eth_call` with contract call and verify return data matches gear
- [ ] Send `eth_estimateGas` and verify estimate is reasonable
- [ ] Send `eth_sendRawTransaction` with a signed EIP-1559 tx
- [ ] Verify WebSocket connection at `/ws` endpoint
- [ ] Compare responses against meter-gear for key methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)