### PR TITLE
fix(runtime): validate native token on clause value transfers

### DIFF
--- a/meter/chain_param.go
+++ b/meter/chain_param.go
@@ -205,6 +205,15 @@ const (
 	TeslaFork13_TestnetStartNum = 78846000
 )
 
+// Fork14
+// Native multi-token value handling: reject clauses carrying an unknown native
+// token byte, and reject non-MTR native value delivered as CALLVALUE into
+// contract code. Fork-gated so historical blocks replay unchanged.
+const (
+	TeslaFork14_MainnetStartNum = 99999999 // FIXME: set to activation block before release
+	TeslaFork14_TestnetStartNum = 99999999 // FIXME: set to activation block before release
+)
+
 var (
 	// BlocktChainConfig is the chain parameters to run a node on the main network.
 	BlockChainConfig = &ChainConfig{
@@ -354,4 +363,8 @@ func IsTeslaFork12(blockNum uint32) bool {
 
 func IsTeslaFork13(blockNum uint32) bool {
 	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork13_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork13_TestnetStartNum)
+}
+
+func IsTeslaFork14(blockNum uint32) bool {
+	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork14_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork14_TestnetStartNum)
 }

--- a/meter/chain_param.go
+++ b/meter/chain_param.go
@@ -211,7 +211,7 @@ const (
 // contract code. Fork-gated so historical blocks replay unchanged.
 const (
 	TeslaFork14_MainnetStartNum = 99999999 // FIXME: set to activation block before release
-	TeslaFork14_TestnetStartNum = 99999999 // FIXME: set to activation block before release
+	TeslaFork14_TestnetStartNum = 99056000
 )
 
 var (

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -645,6 +645,48 @@ func (rt *Runtime) restrictTransfer(stateDB *statedb.StateDB, addr meter.Address
 	}
 }
 
+// rejectInvalidNativeValue enforces, from TeslaFork14 onward, two native-token
+// invariants that the raw EVM value/token plumbing does not guarantee on its
+// own. It returns true when the clause must be rejected before execution.
+//
+//  1. A clause may only carry a known native token (MTR or MTRG). Any other
+//     token byte is rejected: it would pass the MTR balance pre-check in
+//     CanTransfer but move no native value in Transfer, while the EVM still
+//     delivers a non-zero CALLVALUE.
+//  2. Only MTR may be delivered as CALLVALUE into contract code. The EVM exposes
+//     a single CALLVALUE with no notion of which native token supplied it, so
+//     non-MTR value sent into a payable contract (callee with code, or a
+//     contract creation) would be misread as MTR backing. Plain transfers to
+//     non-contract (EOA) recipients are unaffected.
+//
+// Fork-gated so blocks before activation replay bit-for-bit unchanged.
+func (rt *Runtime) rejectInvalidNativeValue(stateDB *statedb.StateDB, clause *tx.Clause, blockNum uint32) bool {
+	if !meter.IsTeslaFork14(blockNum) {
+		return false
+	}
+
+	token := clause.Token()
+
+	// (1) only MTR and MTRG are valid native tokens
+	if token != meter.MTR && token != meter.MTRG {
+		return true
+	}
+
+	// (2) non-MTR native value may not be delivered as CALLVALUE to contract code
+	if token != meter.MTR && clause.Value().Sign() != 0 {
+		to := clause.To()
+		if to == nil {
+			// contract creation: the constructor would observe msg.value
+			return true
+		}
+		if len(stateDB.GetCode(common.Address(*to))) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // SetVMConfig config VM.
 // Returns this runtime.
 func (rt *Runtime) SetVMConfig(config vm.Config) *Runtime {
@@ -1052,6 +1094,26 @@ func (rt *Runtime) PrepareClause(
 				LeftOverGas:     leftOverGas,
 				RefundGas:       stateDB.GetRefund(),
 				VMErr:           errors.New("account is restricted to transfer"),
+				ContractAddress: contractAddr,
+			}
+			return output, false
+		}
+
+		// reject clauses carrying an unknown native token, or delivering non-MTR
+		// native value as CALLVALUE into contract code. See rejectInvalidNativeValue.
+		if rt.rejectInvalidNativeValue(stateDB, clause, rt.ctx.Number) {
+			var leftOverGas uint64
+			if gas > meter.ClauseGas {
+				leftOverGas = gas - meter.ClauseGas
+			} else {
+				leftOverGas = 0
+			}
+
+			output := &Output{
+				Data:            []byte{},
+				LeftOverGas:     leftOverGas,
+				RefundGas:       stateDB.GetRefund(),
+				VMErr:           errors.New("invalid native token transfer"),
 				ContractAddress: contractAddr,
 			}
 			return output, false

--- a/tests/fork14/native_value_token_test.go
+++ b/tests/fork14/native_value_token_test.go
@@ -1,0 +1,88 @@
+package fork14
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/tx"
+	"github.com/meterio/meter-pov/xenv"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	maxGas                = uint64(60000)
+	invalidNativeValueErr = "invalid native token transfer"
+)
+
+// An unknown native token byte must be rejected before execution. Otherwise it
+// passes the MTR balance pre-check in CanTransfer but moves no native value,
+// while the EVM still delivers a non-zero CALLVALUE.
+func TestUnknownTokenIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(byte(2)).WithValue(tests.BuildAmount(1)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+}
+
+// MTRG carried as CALLVALUE into contract code must be rejected: the EVM cannot
+// distinguish it from MTR, so a payable contract would misread it as MTR backing.
+func TestMtrgValueIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(meter.Address(to))
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+
+	// no balance must move when the clause is rejected
+	assert.Equal(t, holderBefore.String(), tenv.State.GetBalance(tests.HolderAddr).String())
+	assert.Equal(t, toBefore.String(), tenv.State.GetBalance(meter.Address(to)).String())
+}
+
+// Plain MTRG transfers to a non-contract (EOA) recipient are unaffected.
+func TestMtrgValueToEOAAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.VoterAddr // dev account, no contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(to)
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.Nil(t, output.VMErr)
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(holderBefore, tenv.State.GetBalance(tests.HolderAddr)).String(), "should sub 50 MTRG from sender")
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(tenv.State.GetBalance(to), toBefore).String(), "should add 50 MTRG to recipient")
+}
+
+// MTR delivered as CALLVALUE into contract code must NOT be blocked by the gate.
+func TestMtrValueIntoContractAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTR).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	// the gate must not fire for MTR; the contract itself may or may not revert,
+	// but it must never be the native-token rejection.
+	if output.VMErr != nil {
+		assert.NotEqual(t, invalidNativeValueErr, output.VMErr.Error())
+	}
+}

--- a/tests/fork14/utils.go
+++ b/tests/fork14/utils.go
@@ -1,0 +1,127 @@
+package fork14
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/builtin"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/genesis"
+	"github.com/meterio/meter-pov/lvldb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/packer"
+	"github.com/meterio/meter-pov/runtime"
+	"github.com/meterio/meter-pov/runtime/statedb"
+	"github.com/meterio/meter-pov/script"
+	"github.com/meterio/meter-pov/state"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/xenv"
+)
+
+func initRuntimeAfterFork14() *tests.TestEnv {
+	tests.InitLogger()
+	kv, _ := lvldb.NewMem()
+	meter.InitBlockChainConfig("main")
+
+	b0 := tests.BuildGenesis(kv, func(state *state.State) error {
+		state.SetCode(builtin.Prototype.Address, builtin.Prototype.RuntimeBytecodes())
+		state.SetCode(builtin.Executor.Address, builtin.Executor.RuntimeBytecodes())
+		state.SetCode(builtin.Params.Address, builtin.Params.RuntimeBytecodes())
+		state.SetCode(builtin.Measure.Address, builtin.Measure.RuntimeBytecodes())
+		builtin.Params.Native(state).Set(meter.KeyExecutorAddress, new(big.Int).SetBytes(builtin.Executor.Address[:]))
+
+		// init MTRG sys contract (gives a recipient address with contract code)
+		state.SetCode(tests.MTRGSysContractAddr, builtin.MeterGovERC20Permit_DeployedBytecode)
+		state.SetStorage(tests.MTRGSysContractAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(builtin.MeterTracker.Address[:]))
+		builtin.Params.Native(state).SetAddress(meter.KeySystemContractAddress1, tests.MTRGSysContractAddr)
+
+		sdb := statedb.New(state)
+
+		// init balance for candidates
+		sdb.MintBalance(common.Address(tests.CandAddr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.CandAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Cand2Addr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.Cand2Addr), tests.BuildAmount(100))
+
+		// init balance for holders
+		sdb.MintBalance(common.Address(tests.HolderAddr), tests.BuildAmount(1200))
+		sdb.MintEnergy(common.Address(tests.HolderAddr), tests.BuildAmount(100))
+
+		// init balance for voters
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(3000))
+		sdb.MintEnergy(common.Address(tests.VoterAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Voter2Addr), tests.BuildAmount(1500))
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(2000000))
+
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+		sdb.BurnEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+
+		// disable previous fork corrections
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla1_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla5_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla_Fork6_Correction, big.NewInt(1))
+
+		// load SampleStakingPool for testing
+		state.SetCode(tests.SampleStakingPoolAddr, tests.SampleStakingPool_DeployedBytes)
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{0}), meter.BytesToBytes32(meter.ScriptEngineSysContractAddr[:]))
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(tests.MTRGSysContractAddr[:]))
+		state.SetEnergy(tests.SampleStakingPoolAddr, tests.BuildAmount(100))
+		state.SetBalance(tests.SampleStakingPoolAddr, tests.BuildAmount(200))
+		return nil
+	})
+	b0.SetQC(&block.QuorumCert{QCHeight: 0, QCRound: 0, EpochID: 0, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	fmt.Println(b0.ID())
+	c, _ := chain.New(kv, b0, false)
+	seeker := c.NewSeeker(b0.ID())
+	sc := state.NewCreator(kv)
+	se := script.NewScriptEngine(c, sc)
+	se.StartTeslaForkModules()
+
+	currentTs := uint64(time.Now().Unix())
+	packer := packer.New(c, sc, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address)
+	flow, err := packer.Mock(b0.Header(), currentTs, 2000000, &meter.Address{})
+	if err != nil {
+		panic(err)
+	}
+	tx1 := tests.BuildCandidateTxForCand(c.Tag(), 2000)
+	if err = flow.Adopt(tx1); err != nil {
+		panic(err)
+	}
+	tx2 := tests.BuildCandidateTxForCand2(c.Tag(), 2000)
+	if err = flow.Adopt(tx2); err != nil {
+		panic(err)
+	}
+	tx3 := tests.BuildVoteTx(c.Tag(), tests.Voter2Key, tests.Voter2Addr, tests.Cand2Addr, tests.BuildAmount(500))
+	if err = flow.Adopt(tx3); err != nil {
+		panic(err)
+	}
+
+	b, stage, receipts, err := flow.Pack(genesis.DevAccounts()[0].PrivateKey, block.MBlockType, 0)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := stage.Commit(); err != nil {
+		panic(err)
+	}
+	b.SetQC(&block.QuorumCert{QCHeight: 1, QCRound: 1, EpochID: 1, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	escortQC := &block.QuorumCert{QCHeight: b.Number(), QCRound: b.QC.QCRound + 1, EpochID: b.QC.EpochID, VoterMsgHash: b.VotingHash()}
+	if _, err = c.AddBlock(b, escortQC, receipts); err != nil {
+		panic(err)
+	}
+	st, _ := state.New(b.Header().StateRoot(), kv)
+	sdb := statedb.New(st)
+
+	rt := runtime.New(seeker, st,
+		&xenv.BlockContext{Time: currentTs,
+			Number: meter.TeslaFork14_MainnetStartNum + 1,
+			Signer: tests.HolderAddr})
+
+	rt.EnforceTeslaFork8_LiquidStaking(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork10_Corrections(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork12_Corrections(sdb, big.NewInt(0))
+	return &tests.TestEnv{Runtime: rt, State: st, BktCreateTS: 0, CurrentTS: currentTs, ChainTag: c.Tag()}
+}


### PR DESCRIPTION
## Summary

Adds a validation step at clause execution time (`Runtime.PrepareClause`) for native-token value handling, which the raw EVM value/token plumbing does not enforce on its own:

1. **Unknown native token bytes are rejected.** A clause may only carry a known native token (`MTR` or `MTRG`). Any other token byte is rejected before execution.
2. **Only MTR may be delivered as CALLVALUE into contract code.** The EVM exposes a single `CALLVALUE` with no notion of which native token supplied it, so non-MTR native value sent into a payable contract (a callee that has code, or a contract creation) is rejected. Plain transfers to non-contract (EOA) recipients are unaffected.

On rejection, the clause reverts with `invalid native token transfer`, charges `ClauseGas`, and mutates no balances — mirroring the existing `restrictTransfer` semantics.

This is **fork-gated behind `TeslaFork14`** so historical blocks replay unchanged: the new validation only applies after the fork activation block. Mainnet/testnet activation block numbers are placeholders (`99999999`) and must be set before release.

## Test plan

- [ ] `tests/fork14/native_value_token_test.go` covers: unknown token to contract rejected; MTRG value to contract rejected (no balances move); MTRG value to EOA allowed; MTR value to contract not blocked by the gate.
- [ ] CI build + `go test ./tests/fork14/`.