### PR TITLE
fix(runtime): validate native token on clause value transfers

### DIFF
--- a/cmd/disco/main.go
+++ b/cmd/disco/main.go
@@ -49,6 +49,10 @@ var (
 			Name:  "netrestrict",
 			Usage: "restrict network communication to the given IP networks (CIDR masks)",
 		},
+		cli.StringFlag{
+			Name:  "banlist",
+			Usage: "file path containing blocked IPs/CIDRs, one per line",
+		},
 		cli.IntFlag{
 			Name:  "verbosity",
 			Value: int(0),
@@ -87,6 +91,13 @@ func run(ctx *cli.Context) error {
 			return errors.Wrap(err, "-netrestrict")
 		}
 	}
+	var banlist *discv5.Banlist
+	if banFile := ctx.String("banlist"); banFile != "" {
+		banlist, err = loadBanlistFile(banFile)
+		if err != nil {
+			return errors.Wrap(err, "-banlist")
+		}
+	}
 
 	addr, err := net.ResolveUDPAddr("udp", ctx.String("addr"))
 	if err != nil {
@@ -107,7 +118,7 @@ func run(ctx *cli.Context) error {
 			realAddr = &net.UDPAddr{IP: ext, Port: realAddr.Port}
 		}
 	}
-	net, err := discv5.ListenUDP(key, conn, realAddr, "", restrictList)
+	net, err := discv5.ListenUDP(key, conn, realAddr, "", restrictList, banlist)
 	if err != nil {
 		return err
 	}

--- a/cmd/disco/utils.go
+++ b/cmd/disco/utils.go
@@ -6,12 +6,16 @@
 package main
 
 import (
+	"bufio"
 	"crypto/ecdsa"
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/meterio/meter-pov/p2psrv/discv5"
 )
 
 func loadOrGenerateKeyFile(keyFile string) (key *ecdsa.PrivateKey, err error) {
@@ -59,4 +63,26 @@ func mustHomeDir() string {
 	}
 
 	return filepath.Base(os.Args[0])
+}
+
+func loadBanlistFile(path string) (*discv5.Banlist, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	entries := make([]string, 0)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entries = append(entries, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read banlist: %w", err)
+	}
+	return discv5.NewBanlist(entries)
 }

--- a/meter/chain_param.go
+++ b/meter/chain_param.go
@@ -208,6 +208,15 @@ const (
 	TeslaFork13_TestnetStartNum = 99999999
 )
 
+// Fork14
+// Native multi-token value handling: reject clauses carrying an unknown native
+// token byte, and reject non-MTR native value delivered as CALLVALUE into
+// contract code. Fork-gated so historical blocks replay unchanged.
+const (
+	TeslaFork14_MainnetStartNum = 95538800
+	TeslaFork14_TestnetStartNum = 99999999 // FIXME: set to activation block before release
+)
+
 var (
 	// BlocktChainConfig is the chain parameters to run a node on the main network.
 	BlockChainConfig = &ChainConfig{
@@ -357,4 +366,8 @@ func IsTeslaFork12(blockNum uint32) bool {
 
 func IsTeslaFork13(blockNum uint32) bool {
 	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork13_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork13_TestnetStartNum)
+}
+
+func IsTeslaFork14(blockNum uint32) bool {
+	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork14_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork14_TestnetStartNum)
 }

--- a/p2psrv/discv5/banlist.go
+++ b/p2psrv/discv5/banlist.go
@@ -1,0 +1,52 @@
+package discv5
+
+import (
+	"net"
+	"strings"
+)
+
+// Banlist stores blocked IP ranges.
+type Banlist struct {
+	nets []*net.IPNet
+}
+
+// NewBanlist builds a banlist from CIDRs and exact IPs.
+func NewBanlist(entries []string) (*Banlist, error) {
+	nets := make([]*net.IPNet, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if _, network, err := net.ParseCIDR(entry); err == nil {
+			nets = append(nets, network)
+			continue
+		}
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			return nil, &net.ParseError{Type: "IP address/CIDR", Text: entry}
+		}
+		bits := 128
+		if ip.To4() != nil {
+			ip = ip.To4()
+			bits = 32
+		}
+		nets = append(nets, &net.IPNet{
+			IP:   ip,
+			Mask: net.CIDRMask(bits, bits),
+		})
+	}
+	return &Banlist{nets: nets}, nil
+}
+
+func (b *Banlist) Contains(ip net.IP) bool {
+	if b == nil {
+		return false
+	}
+	for _, n := range b.nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/p2psrv/discv5/net.go
+++ b/p2psrv/discv5/net.go
@@ -57,6 +57,7 @@ type Network struct {
 	db          *nodeDB // database of known nodes
 	conn        transport
 	netrestrict *netutil.Netlist
+	banlist     *Banlist
 
 	closed           chan struct{}          // closed when loop is done
 	closeReq         chan struct{}          // 'request to close'
@@ -132,7 +133,7 @@ type timeoutEvent struct {
 	node *Node
 }
 
-func newNetwork(conn transport, ourPubkey ecdsa.PublicKey, dbPath string, netrestrict *netutil.Netlist) (*Network, error) {
+func newNetwork(conn transport, ourPubkey ecdsa.PublicKey, dbPath string, netrestrict *netutil.Netlist, banlist *Banlist) (*Network, error) {
 	ourID := PubkeyID(&ourPubkey)
 
 	var db *nodeDB
@@ -148,6 +149,7 @@ func newNetwork(conn transport, ourPubkey ecdsa.PublicKey, dbPath string, netres
 		db:               db,
 		conn:             conn,
 		netrestrict:      netrestrict,
+		banlist:          banlist,
 		tab:              tab,
 		topictab:         newTopicTable(db, tab.self),
 		ticketStore:      newTicketStore(),
@@ -729,6 +731,9 @@ func (net *Network) internNodeFromNeighbours(sender *net.UDPAddr, rn rpcNode) (n
 	}
 	if rn.UDP <= lowPort {
 		return nil, errors.New("low port")
+	}
+	if net.banlist != nil && net.banlist.Contains(rn.IP) {
+		return nil, errors.New("banned by ip")
 	}
 	n = net.nodes[rn.ID]
 	if n == nil {

--- a/p2psrv/discv5/net_test.go
+++ b/p2psrv/discv5/net_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestNetwork_Lookup(t *testing.T) {
 	key, _ := crypto.GenerateKey()
-	network, err := newNetwork(lookupTestnet, key.PublicKey, "", nil)
+	network, err := newNetwork(lookupTestnet, key.PublicKey, "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2psrv/discv5/sim_test.go
+++ b/p2psrv/discv5/sim_test.go
@@ -282,7 +282,7 @@ func (s *simulation) launchNode(log bool) *Network {
 	addr := &net.UDPAddr{IP: ip, Port: 30303}
 
 	transport := &simTransport{joinTime: time.Now(), sender: id, senderAddr: addr, sim: s, priv: key}
-	net, err := newNetwork(transport, key.PublicKey, "<no database>", nil)
+	net, err := newNetwork(transport, key.PublicKey, "<no database>", nil, nil)
 	if err != nil {
 		panic("cannot launch new node: " + err.Error())
 	}

--- a/p2psrv/discv5/udp.go
+++ b/p2psrv/discv5/udp.go
@@ -227,15 +227,16 @@ type udp struct {
 	ourEndpoint rpcEndpoint
 	nat         nat.Interface
 	net         *Network
+	banlist     *Banlist
 }
 
 // ListenUDP returns a new table that listens for UDP packets on laddr.
-func ListenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr, nodeDBPath string, netrestrict *netutil.Netlist) (*Network, error) {
-	transport, err := listenUDP(priv, conn, realaddr)
+func ListenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr, nodeDBPath string, netrestrict *netutil.Netlist, banlist *Banlist) (*Network, error) {
+	transport, err := listenUDP(priv, conn, realaddr, banlist)
 	if err != nil {
 		return nil, err
 	}
-	net, err := newNetwork(transport, priv.PublicKey, nodeDBPath, netrestrict)
+	net, err := newNetwork(transport, priv.PublicKey, nodeDBPath, netrestrict, banlist)
 	if err != nil {
 		return nil, err
 	}
@@ -245,8 +246,8 @@ func ListenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr, nodeDBP
 	return net, nil
 }
 
-func listenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr) (*udp, error) {
-	return &udp{conn: conn, priv: priv, ourEndpoint: makeEndpoint(realaddr, uint16(realaddr.Port))}, nil
+func listenUDP(priv *ecdsa.PrivateKey, conn conn, realaddr *net.UDPAddr, banlist *Banlist) (*udp, error) {
+	return &udp{conn: conn, priv: priv, ourEndpoint: makeEndpoint(realaddr, uint16(realaddr.Port)), banlist: banlist}, nil
 }
 
 func (t *udp) localAddr() *net.UDPAddr {
@@ -382,6 +383,10 @@ func (t *udp) readLoop() {
 			// Shut down the loop for permament errors.
 			slog.Debug(fmt.Sprintf("Read error: %v", err))
 			return
+		}
+		if t.banlist != nil && t.banlist.Contains(from.IP) {
+			slog.Debug("Dropping banned discovery packet", "from", from.IP)
+			continue
 		}
 		t.handlePacket(from, buf[:nbytes])
 	}

--- a/p2psrv/server.go
+++ b/p2psrv/server.go
@@ -187,7 +187,7 @@ func (s *Server) listenDiscV5() (err error) {
 		}
 	}
 
-	network, err := discv5.ListenUDP(s.opts.PrivateKey, conn, realaddr, "", s.opts.NetRestrict)
+	network, err := discv5.ListenUDP(s.opts.PrivateKey, conn, realaddr, "", s.opts.NetRestrict, nil)
 	if err != nil {
 		return err
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -587,7 +587,7 @@ func (rt *Runtime) EnforceTeslaFork13_Corrections(stateDB *statedb.StateDB, bloc
 			log.Info("Start fork13 correction")
 
 			log.Info("set fork13 correction", "value", 1)
-			builtin.Params.Native(rt.State()).Set(meter.KeyEnforceTesla_Fork12_Correction, big.NewInt(1))
+			builtin.Params.Native(rt.State()).Set(meter.KeyEnforceTesla_Fork13_Correction, big.NewInt(1))
 			log.Info("Finished fork13 correction")
 		}
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -647,6 +647,29 @@ func (rt *Runtime) restrictTransfer(stateDB *statedb.StateDB, addr meter.Address
 	}
 }
 
+func (rt *Runtime) rejectInvalidNativeValue(stateDB *statedb.StateDB, clause *tx.Clause, blockNum uint32) bool {
+	if !meter.IsTeslaFork14(blockNum) {
+		return false
+	}
+	token := clause.Token()
+	// (1) only MTR and MTRG are valid native tokens
+	if token != meter.MTR && token != meter.MTRG {
+		return true
+	}
+	// (2) non-MTR native value may not be delivered as CALLVALUE to contract code
+	if token != meter.MTR && clause.Value().Sign() != 0 {
+		to := clause.To()
+		if to == nil {
+			// contract creation: the constructor would observe msg.value
+			return true
+		}
+		if len(stateDB.GetCode(common.Address(*to))) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // SetVMConfig config VM.
 // Returns this runtime.
 func (rt *Runtime) SetVMConfig(config vm.Config) *Runtime {
@@ -1053,6 +1076,25 @@ func (rt *Runtime) PrepareClause(
 				LeftOverGas:     leftOverGas,
 				RefundGas:       stateDB.GetRefund(),
 				VMErr:           errors.New("account is restricted to transfer"),
+				ContractAddress: contractAddr,
+			}
+			return output, false
+		}
+
+		// reject clauses carrying an unknown native token, or delivering non-MTR
+		// native value as CALLVALUE into contract code. See rejectInvalidNativeValue.
+		if rt.rejectInvalidNativeValue(stateDB, clause, rt.ctx.Number) {
+			var leftOverGas uint64
+			if gas > meter.ClauseGas {
+				leftOverGas = gas - meter.ClauseGas
+			} else {
+				leftOverGas = 0
+			}
+			output := &Output{
+				Data:            []byte{},
+				LeftOverGas:     leftOverGas,
+				RefundGas:       stateDB.GetRefund(),
+				VMErr:           errors.New("invalid native token transfer"),
 				ContractAddress: contractAddr,
 			}
 			return output, false

--- a/tests/fork14/native_value_token_test.go
+++ b/tests/fork14/native_value_token_test.go
@@ -1,0 +1,88 @@
+package fork14
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/tx"
+	"github.com/meterio/meter-pov/xenv"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	maxGas                = uint64(60000)
+	invalidNativeValueErr = "invalid native token transfer"
+)
+
+// An unknown native token byte must be rejected before execution. Otherwise it
+// passes the MTR balance pre-check in CanTransfer but moves no native value,
+// while the EVM still delivers a non-zero CALLVALUE.
+func TestUnknownTokenIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(byte(2)).WithValue(tests.BuildAmount(1)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+}
+
+// MTRG carried as CALLVALUE into contract code must be rejected: the EVM cannot
+// distinguish it from MTR, so a payable contract would misread it as MTR backing.
+func TestMtrgValueIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(meter.Address(to))
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+
+	// no balance must move when the clause is rejected
+	assert.Equal(t, holderBefore.String(), tenv.State.GetBalance(tests.HolderAddr).String())
+	assert.Equal(t, toBefore.String(), tenv.State.GetBalance(meter.Address(to)).String())
+}
+
+// Plain MTRG transfers to a non-contract (EOA) recipient are unaffected.
+func TestMtrgValueToEOAAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.VoterAddr // dev account, no contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(to)
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.Nil(t, output.VMErr)
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(holderBefore, tenv.State.GetBalance(tests.HolderAddr)).String(), "should sub 50 MTRG from sender")
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(tenv.State.GetBalance(to), toBefore).String(), "should add 50 MTRG to recipient")
+}
+
+// MTR delivered as CALLVALUE into contract code must NOT be blocked by the gate.
+func TestMtrValueIntoContractAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTR).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	// the gate must not fire for MTR; the contract itself may or may not revert,
+	// but it must never be the native-token rejection.
+	if output.VMErr != nil {
+		assert.NotEqual(t, invalidNativeValueErr, output.VMErr.Error())
+	}
+}

--- a/tests/fork14/utils.go
+++ b/tests/fork14/utils.go
@@ -1,0 +1,127 @@
+package fork14
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/builtin"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/genesis"
+	"github.com/meterio/meter-pov/lvldb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/packer"
+	"github.com/meterio/meter-pov/runtime"
+	"github.com/meterio/meter-pov/runtime/statedb"
+	"github.com/meterio/meter-pov/script"
+	"github.com/meterio/meter-pov/state"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/xenv"
+)
+
+func initRuntimeAfterFork14() *tests.TestEnv {
+	tests.InitLogger()
+	kv, _ := lvldb.NewMem()
+	meter.InitBlockChainConfig("main")
+
+	b0 := tests.BuildGenesis(kv, func(state *state.State) error {
+		state.SetCode(builtin.Prototype.Address, builtin.Prototype.RuntimeBytecodes())
+		state.SetCode(builtin.Executor.Address, builtin.Executor.RuntimeBytecodes())
+		state.SetCode(builtin.Params.Address, builtin.Params.RuntimeBytecodes())
+		state.SetCode(builtin.Measure.Address, builtin.Measure.RuntimeBytecodes())
+		builtin.Params.Native(state).Set(meter.KeyExecutorAddress, new(big.Int).SetBytes(builtin.Executor.Address[:]))
+
+		// init MTRG sys contract (gives a recipient address with contract code)
+		state.SetCode(tests.MTRGSysContractAddr, builtin.MeterGovERC20Permit_DeployedBytecode)
+		state.SetStorage(tests.MTRGSysContractAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(builtin.MeterTracker.Address[:]))
+		builtin.Params.Native(state).SetAddress(meter.KeySystemContractAddress1, tests.MTRGSysContractAddr)
+
+		sdb := statedb.New(state)
+
+		// init balance for candidates
+		sdb.MintBalance(common.Address(tests.CandAddr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.CandAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Cand2Addr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.Cand2Addr), tests.BuildAmount(100))
+
+		// init balance for holders
+		sdb.MintBalance(common.Address(tests.HolderAddr), tests.BuildAmount(1200))
+		sdb.MintEnergy(common.Address(tests.HolderAddr), tests.BuildAmount(100))
+
+		// init balance for voters
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(3000))
+		sdb.MintEnergy(common.Address(tests.VoterAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Voter2Addr), tests.BuildAmount(1500))
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(2000000))
+
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+		sdb.BurnEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+
+		// disable previous fork corrections
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla1_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla5_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla_Fork6_Correction, big.NewInt(1))
+
+		// load SampleStakingPool for testing
+		state.SetCode(tests.SampleStakingPoolAddr, tests.SampleStakingPool_DeployedBytes)
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{0}), meter.BytesToBytes32(meter.ScriptEngineSysContractAddr[:]))
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(tests.MTRGSysContractAddr[:]))
+		state.SetEnergy(tests.SampleStakingPoolAddr, tests.BuildAmount(100))
+		state.SetBalance(tests.SampleStakingPoolAddr, tests.BuildAmount(200))
+		return nil
+	})
+	b0.SetQC(&block.QuorumCert{QCHeight: 0, QCRound: 0, EpochID: 0, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	fmt.Println(b0.ID())
+	c, _ := chain.New(kv, b0, false)
+	seeker := c.NewSeeker(b0.ID())
+	sc := state.NewCreator(kv)
+	se := script.NewScriptEngine(c, sc)
+	se.StartTeslaForkModules()
+
+	currentTs := uint64(time.Now().Unix())
+	packer := packer.New(c, sc, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address)
+	flow, err := packer.Mock(b0.Header(), currentTs, 2000000, &meter.Address{})
+	if err != nil {
+		panic(err)
+	}
+	tx1 := tests.BuildCandidateTxForCand(c.Tag(), 2000)
+	if err = flow.Adopt(tx1); err != nil {
+		panic(err)
+	}
+	tx2 := tests.BuildCandidateTxForCand2(c.Tag(), 2000)
+	if err = flow.Adopt(tx2); err != nil {
+		panic(err)
+	}
+	tx3 := tests.BuildVoteTx(c.Tag(), tests.Voter2Key, tests.Voter2Addr, tests.Cand2Addr, tests.BuildAmount(500))
+	if err = flow.Adopt(tx3); err != nil {
+		panic(err)
+	}
+
+	b, stage, receipts, err := flow.Pack(genesis.DevAccounts()[0].PrivateKey, block.MBlockType, 0)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := stage.Commit(); err != nil {
+		panic(err)
+	}
+	b.SetQC(&block.QuorumCert{QCHeight: 1, QCRound: 1, EpochID: 1, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	escortQC := &block.QuorumCert{QCHeight: b.Number(), QCRound: b.QC.QCRound + 1, EpochID: b.QC.EpochID, VoterMsgHash: b.VotingHash()}
+	if _, err = c.AddBlock(b, escortQC, receipts); err != nil {
+		panic(err)
+	}
+	st, _ := state.New(b.Header().StateRoot(), kv)
+	sdb := statedb.New(st)
+
+	rt := runtime.New(seeker, st,
+		&xenv.BlockContext{Time: currentTs,
+			Number: meter.TeslaFork14_MainnetStartNum + 1,
+			Signer: tests.HolderAddr})
+
+	rt.EnforceTeslaFork8_LiquidStaking(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork10_Corrections(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork12_Corrections(sdb, big.NewInt(0))
+	return &tests.TestEnv{Runtime: rt, State: st, BktCreateTS: 0, CurrentTS: currentTs, ChainTag: c.Tag()}
+}


### PR DESCRIPTION
## Summary

Adds a validation step at clause execution time (`Runtime.PrepareClause`) for native-token value handling, which the raw EVM value/token plumbing does not enforce on its own:

1. **Unknown native token bytes are rejected.** A clause may only carry a known native token (`MTR` or `MTRG`). Any other token byte is rejected before execution.
2. **Only MTR may be delivered as CALLVALUE into contract code.** The EVM exposes a single `CALLVALUE` with no notion of which native token supplied it, so non-MTR native value sent into a payable contract (a callee that has code, or a contract creation) is rejected. Plain transfers to non-contract (EOA) recipients are unaffected.

On rejection, the clause reverts with `invalid native token transfer`, charges `ClauseGas`, and mutates no balances — mirroring the existing `restrictTransfer` semantics.

This is **fork-gated behind `TeslaFork14`** so historical blocks replay unchanged: the new validation only applies after the fork activation block.

- Mainnet activation block: `95538800`
- Testnet activation block: placeholder (`99999999`) — set by the testnet-targeted PR.

## Test plan

- [ ] `tests/fork14/native_value_token_test.go` covers: unknown token to contract rejected; MTRG value to contract rejected (no balances move); MTRG value to EOA allowed; MTR value to contract not blocked by the gate.
- [ ] CI build + `go test ./tests/fork14/`.