### PR TITLE
CHAINS-0: introduce TeslaFork14 (set the never-set Fork13 correction flag)

### DIFF
--- a/meter/chain_param.go
+++ b/meter/chain_param.go
@@ -219,7 +219,7 @@ const (
 //     send MTRG (governance) value into a contract, which the EVM single-CALLVALUE
 //     model cannot represent safely.
 const (
-	TeslaFork14_MainnetStartNum = 95538800
+	TeslaFork14_MainnetStartNum = 95627400
 	TeslaFork14_TestnetStartNum = 99056000
 )
 

--- a/meter/chain_param.go
+++ b/meter/chain_param.go
@@ -208,6 +208,21 @@ const (
 	TeslaFork13_TestnetStartNum = 99999999
 )
 
+// Fork14 fixes include:
+//  1. Set the Fork13 correction flag (KeyEnforceTesla_Fork13_Correction).
+//     The mainnet-deployed Fork13 correction had a copy-paste bug: it wrote the
+//     Fork12 key instead of the Fork13 key, so the Fork13 flag was never set.
+//     Fork14 corrects this at a coordinated future block so all nodes write the
+//     same state (setting it retroactively at the passed Fork13 height would fork
+//     the chain).
+//  2. Reject native-token transfers that carry an unknown token identifier or that
+//     send MTRG (governance) value into a contract, which the EVM single-CALLVALUE
+//     model cannot represent safely.
+const (
+	TeslaFork14_MainnetStartNum = 95538800
+	TeslaFork14_TestnetStartNum = 99056000
+)
+
 var (
 	// BlocktChainConfig is the chain parameters to run a node on the main network.
 	BlockChainConfig = &ChainConfig{
@@ -357,4 +372,8 @@ func IsTeslaFork12(blockNum uint32) bool {
 
 func IsTeslaFork13(blockNum uint32) bool {
 	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork13_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork13_TestnetStartNum)
+}
+
+func IsTeslaFork14(blockNum uint32) bool {
+	return (BlockChainConfig.IsMainnet() && blockNum > TeslaFork14_MainnetStartNum) || (BlockChainConfig.IsTestnet() && blockNum > TeslaFork14_TestnetStartNum)
 }

--- a/meter/params.go
+++ b/meter/params.go
@@ -157,6 +157,8 @@ var (
 	KeyTesla_Fork12_Timestamp         = BytesToBytes32([]byte("Tesla_Fork12_Timestamp"))
 
 	KeyEnforceTesla_Fork13_Correction = BytesToBytes32([]byte("Tesla_Fork13_Correction")) // unset or 0 is not do yet, 1 is done
+
+	KeyEnforceTesla_Fork14_Correction = BytesToBytes32([]byte("Tesla_Fork14_Correction")) // unset or 0 is not do yet, 1 is done
 	// KeyBaseSequence_AfterFork11       = BytesToBytes32([]byte("BaseSequence_AfterFork11")) // base sequence after fork11
 	// key set transaction fee address
 	// 0x6e73616374696f6e2d6665652d62656e65666963696172792d61646472657373

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -593,6 +593,31 @@ func (rt *Runtime) EnforceTeslaFork13_Corrections(stateDB *statedb.StateDB, bloc
 	}
 }
 
+// EnforceTeslaFork14_Corrections fixes the Fork13 correction copy-paste bug.
+// The deployed EnforceTeslaFork13_Corrections wrote KeyEnforceTesla_Fork12_Correction
+// instead of KeyEnforceTesla_Fork13_Correction, so the Fork13 flag was never set on
+// mainnet. We cannot retroactively set it at the already-passed Fork13 height without
+// forking the chain, so Fork14 sets both the Fork13 and Fork14 flags at a coordinated
+// future block so every node writes the same state.
+func (rt *Runtime) EnforceTeslaFork14_Corrections(stateDB *statedb.StateDB, blockNum *big.Int) {
+	blockNumber := rt.Context().Number
+	log := slog.With("pkg", "fork14")
+	if blockNumber > 0 {
+		// flag is nil or 0, is not do. 1 means done.
+		enforceFlag := builtin.Params.Native(rt.State()).Get(meter.KeyEnforceTesla_Fork14_Correction)
+
+		if meter.IsTeslaFork14(blockNumber) && (enforceFlag == nil || enforceFlag.Sign() == 0) {
+			log.Info("Start fork14 correction")
+
+			log.Info("set fork13 correction", "value", 1)
+			builtin.Params.Native(rt.State()).Set(meter.KeyEnforceTesla_Fork13_Correction, big.NewInt(1))
+			log.Info("set fork14 correction", "value", 1)
+			builtin.Params.Native(rt.State()).Set(meter.KeyEnforceTesla_Fork14_Correction, big.NewInt(1))
+			log.Info("Finished fork14 correction")
+		}
+	}
+}
+
 func (rt *Runtime) FromNativeContract(caller meter.Address) bool {
 
 	nativeMtrERC20 := builtin.Params.Native(rt.State()).GetAddress(meter.KeyNativeMtrERC20Address)
@@ -645,6 +670,43 @@ func (rt *Runtime) restrictTransfer(stateDB *statedb.StateDB, addr meter.Address
 		needed := new(big.Int).Add(lockMtrg, amount)
 		return stateDB.GetBalance(common.Address(addr)).Cmp(needed) < 0
 	}
+}
+
+// rejectInvalidNativeValue enforces, from TeslaFork14 onward, two native-token
+// invariants that the EVM's single CALLVALUE model cannot represent safely:
+//  1. Only MTR and MTRG are valid native tokens; any other token identifier is
+//     rejected outright.
+//  2. Non-MTR native value (e.g. MTRG, the governance token) may not be delivered
+//     as CALLVALUE into contract code, because the EVM cannot distinguish which
+//     native token a CALLVALUE represents. Such value is only allowed when sent to
+//     a plain externally-owned account (EOA).
+//
+// Returns true when the clause must be rejected.
+func (rt *Runtime) rejectInvalidNativeValue(stateDB *statedb.StateDB, clause *tx.Clause, blockNum uint32) bool {
+	if !meter.IsTeslaFork14(blockNum) {
+		return false
+	}
+
+	token := clause.Token()
+
+	// (1) only MTR and MTRG are valid native tokens
+	if token != meter.MTR && token != meter.MTRG {
+		return true
+	}
+
+	// (2) non-MTR native value may not be delivered as CALLVALUE to contract code
+	if token != meter.MTR && clause.Value().Sign() != 0 {
+		to := clause.To()
+		if to == nil {
+			// contract creation: the constructor would observe msg.value
+			return true
+		}
+		if len(stateDB.GetCode(common.Address(*to))) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // SetVMConfig config VM.
@@ -1039,6 +1101,9 @@ func (rt *Runtime) PrepareClause(
 
 		rt.EnforceTeslaFork13_Corrections(stateDB, evm.BlockNumber)
 
+		// tesla fork14: set the (previously never-set) fork13 flag and the fork14 flag
+		rt.EnforceTeslaFork14_Corrections(stateDB, evm.BlockNumber)
+
 		// check the restriction of transfer.
 		if rt.restrictTransfer(stateDB, txCtx.Origin, clause.Value(), clause.Token(), rt.ctx.Number) == true {
 			var leftOverGas uint64
@@ -1053,6 +1118,26 @@ func (rt *Runtime) PrepareClause(
 				LeftOverGas:     leftOverGas,
 				RefundGas:       stateDB.GetRefund(),
 				VMErr:           errors.New("account is restricted to transfer"),
+				ContractAddress: contractAddr,
+			}
+			return output, false
+		}
+
+		// reject clauses carrying an unknown native token, or delivering non-MTR
+		// native value as CALLVALUE into contract code. See rejectInvalidNativeValue.
+		if rt.rejectInvalidNativeValue(stateDB, clause, rt.ctx.Number) {
+			var leftOverGas uint64
+			if gas > meter.ClauseGas {
+				leftOverGas = gas - meter.ClauseGas
+			} else {
+				leftOverGas = 0
+			}
+
+			output := &Output{
+				Data:            []byte{},
+				LeftOverGas:     leftOverGas,
+				RefundGas:       stateDB.GetRefund(),
+				VMErr:           errors.New("invalid native token transfer"),
 				ContractAddress: contractAddr,
 			}
 			return output, false

--- a/tests/fork14/fork14_correction_test.go
+++ b/tests/fork14/fork14_correction_test.go
@@ -1,0 +1,35 @@
+package fork14
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/meterio/meter-pov/builtin"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/runtime/statedb"
+	"github.com/stretchr/testify/assert"
+)
+
+// The mainnet-deployed EnforceTeslaFork13_Corrections had a copy-paste bug: it
+// wrote KeyEnforceTesla_Fork12_Correction instead of KeyEnforceTesla_Fork13_Correction,
+// so the Fork13 flag was never set. Fork14 must set BOTH the Fork13 and the Fork14
+// flags at the coordinated Fork14 block.
+func TestFork14SetsFork13AndFork14Flags(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	sdb := statedb.New(tenv.State)
+
+	// precondition: neither flag is set yet
+	f13Before := builtin.Params.Native(tenv.State).Get(meter.KeyEnforceTesla_Fork13_Correction)
+	f14Before := builtin.Params.Native(tenv.State).Get(meter.KeyEnforceTesla_Fork14_Correction)
+	assert.True(t, f13Before == nil || f13Before.Sign() == 0, "fork13 flag should be unset before fork14 correction")
+	assert.True(t, f14Before == nil || f14Before.Sign() == 0, "fork14 flag should be unset before fork14 correction")
+
+	tenv.Runtime.EnforceTeslaFork14_Corrections(sdb, big.NewInt(0))
+
+	f13After := builtin.Params.Native(tenv.State).Get(meter.KeyEnforceTesla_Fork13_Correction)
+	f14After := builtin.Params.Native(tenv.State).Get(meter.KeyEnforceTesla_Fork14_Correction)
+	assert.NotNil(t, f13After)
+	assert.Equal(t, int64(1), f13After.Int64(), "fork13 flag should be set to 1 by fork14 correction")
+	assert.NotNil(t, f14After)
+	assert.Equal(t, int64(1), f14After.Int64(), "fork14 flag should be set to 1 by fork14 correction")
+}

--- a/tests/fork14/native_value_token_test.go
+++ b/tests/fork14/native_value_token_test.go
@@ -1,0 +1,88 @@
+package fork14
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/tx"
+	"github.com/meterio/meter-pov/xenv"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	maxGas                = uint64(60000)
+	invalidNativeValueErr = "invalid native token transfer"
+)
+
+// An unknown native token byte must be rejected before execution. Otherwise it
+// passes the MTR balance pre-check in CanTransfer but moves no native value,
+// while the EVM still delivers a non-zero CALLVALUE.
+func TestUnknownTokenIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(byte(2)).WithValue(tests.BuildAmount(1)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+}
+
+// MTRG carried as CALLVALUE into contract code must be rejected: the EVM cannot
+// distinguish it from MTR, so a payable contract would misread it as MTR backing.
+func TestMtrgValueIntoContractRejected(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(meter.Address(to))
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.NotNil(t, output.VMErr)
+	assert.Equal(t, invalidNativeValueErr, output.VMErr.Error())
+
+	// no balance must move when the clause is rejected
+	assert.Equal(t, holderBefore.String(), tenv.State.GetBalance(tests.HolderAddr).String())
+	assert.Equal(t, toBefore.String(), tenv.State.GetBalance(meter.Address(to)).String())
+}
+
+// Plain MTRG transfers to a non-contract (EOA) recipient are unaffected.
+func TestMtrgValueToEOAAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.VoterAddr // dev account, no contract code
+
+	holderBefore := tenv.State.GetBalance(tests.HolderAddr)
+	toBefore := tenv.State.GetBalance(to)
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTRG).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	assert.Nil(t, output.VMErr)
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(holderBefore, tenv.State.GetBalance(tests.HolderAddr)).String(), "should sub 50 MTRG from sender")
+	assert.Equal(t, tests.BuildAmount(50).String(),
+		new(big.Int).Sub(tenv.State.GetBalance(to), toBefore).String(), "should add 50 MTRG to recipient")
+}
+
+// MTR delivered as CALLVALUE into contract code must NOT be blocked by the gate.
+func TestMtrValueIntoContractAllowed(t *testing.T) {
+	tenv := initRuntimeAfterFork14()
+	to := tests.MTRGSysContractAddr // has contract code
+
+	output := tenv.Runtime.ExecuteClause(
+		tx.NewClause(&to).WithToken(meter.MTR).WithValue(tests.BuildAmount(50)),
+		0, maxGas, &xenv.TransactionContext{Origin: tests.HolderAddr})
+
+	// the gate must not fire for MTR; the contract itself may or may not revert,
+	// but it must never be the native-token rejection.
+	if output.VMErr != nil {
+		assert.NotEqual(t, invalidNativeValueErr, output.VMErr.Error())
+	}
+}

--- a/tests/fork14/utils.go
+++ b/tests/fork14/utils.go
@@ -1,0 +1,127 @@
+package fork14
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/meterio/meter-pov/block"
+	"github.com/meterio/meter-pov/builtin"
+	"github.com/meterio/meter-pov/chain"
+	"github.com/meterio/meter-pov/genesis"
+	"github.com/meterio/meter-pov/lvldb"
+	"github.com/meterio/meter-pov/meter"
+	"github.com/meterio/meter-pov/packer"
+	"github.com/meterio/meter-pov/runtime"
+	"github.com/meterio/meter-pov/runtime/statedb"
+	"github.com/meterio/meter-pov/script"
+	"github.com/meterio/meter-pov/state"
+	"github.com/meterio/meter-pov/tests"
+	"github.com/meterio/meter-pov/xenv"
+)
+
+func initRuntimeAfterFork14() *tests.TestEnv {
+	tests.InitLogger()
+	kv, _ := lvldb.NewMem()
+	meter.InitBlockChainConfig("main")
+
+	b0 := tests.BuildGenesis(kv, func(state *state.State) error {
+		state.SetCode(builtin.Prototype.Address, builtin.Prototype.RuntimeBytecodes())
+		state.SetCode(builtin.Executor.Address, builtin.Executor.RuntimeBytecodes())
+		state.SetCode(builtin.Params.Address, builtin.Params.RuntimeBytecodes())
+		state.SetCode(builtin.Measure.Address, builtin.Measure.RuntimeBytecodes())
+		builtin.Params.Native(state).Set(meter.KeyExecutorAddress, new(big.Int).SetBytes(builtin.Executor.Address[:]))
+
+		// init MTRG sys contract (gives a recipient address with contract code)
+		state.SetCode(tests.MTRGSysContractAddr, builtin.MeterGovERC20Permit_DeployedBytecode)
+		state.SetStorage(tests.MTRGSysContractAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(builtin.MeterTracker.Address[:]))
+		builtin.Params.Native(state).SetAddress(meter.KeySystemContractAddress1, tests.MTRGSysContractAddr)
+
+		sdb := statedb.New(state)
+
+		// init balance for candidates
+		sdb.MintBalance(common.Address(tests.CandAddr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.CandAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Cand2Addr), tests.BuildAmount(2000))
+		sdb.MintEnergy(common.Address(tests.Cand2Addr), tests.BuildAmount(100))
+
+		// init balance for holders
+		sdb.MintBalance(common.Address(tests.HolderAddr), tests.BuildAmount(1200))
+		sdb.MintEnergy(common.Address(tests.HolderAddr), tests.BuildAmount(100))
+
+		// init balance for voters
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(3000))
+		sdb.MintEnergy(common.Address(tests.VoterAddr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.Voter2Addr), tests.BuildAmount(1500))
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(100))
+		sdb.MintBalance(common.Address(tests.VoterAddr), tests.BuildAmount(2000000))
+
+		sdb.MintEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+		sdb.BurnEnergy(common.Address(tests.Voter2Addr), tests.BuildAmount(1234))
+
+		// disable previous fork corrections
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla1_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla5_Correction, big.NewInt(1))
+		builtin.Params.Native(state).Set(meter.KeyEnforceTesla_Fork6_Correction, big.NewInt(1))
+
+		// load SampleStakingPool for testing
+		state.SetCode(tests.SampleStakingPoolAddr, tests.SampleStakingPool_DeployedBytes)
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{0}), meter.BytesToBytes32(meter.ScriptEngineSysContractAddr[:]))
+		state.SetStorage(tests.SampleStakingPoolAddr, meter.BytesToBytes32([]byte{1}), meter.BytesToBytes32(tests.MTRGSysContractAddr[:]))
+		state.SetEnergy(tests.SampleStakingPoolAddr, tests.BuildAmount(100))
+		state.SetBalance(tests.SampleStakingPoolAddr, tests.BuildAmount(200))
+		return nil
+	})
+	b0.SetQC(&block.QuorumCert{QCHeight: 0, QCRound: 0, EpochID: 0, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	fmt.Println(b0.ID())
+	c, _ := chain.New(kv, b0, false)
+	seeker := c.NewSeeker(b0.ID())
+	sc := state.NewCreator(kv)
+	se := script.NewScriptEngine(c, sc)
+	se.StartTeslaForkModules()
+
+	currentTs := uint64(time.Now().Unix())
+	packer := packer.New(c, sc, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address)
+	flow, err := packer.Mock(b0.Header(), currentTs, 2000000, &meter.Address{})
+	if err != nil {
+		panic(err)
+	}
+	tx1 := tests.BuildCandidateTxForCand(c.Tag(), 2000)
+	if err = flow.Adopt(tx1); err != nil {
+		panic(err)
+	}
+	tx2 := tests.BuildCandidateTxForCand2(c.Tag(), 2000)
+	if err = flow.Adopt(tx2); err != nil {
+		panic(err)
+	}
+	tx3 := tests.BuildVoteTx(c.Tag(), tests.Voter2Key, tests.Voter2Addr, tests.Cand2Addr, tests.BuildAmount(500))
+	if err = flow.Adopt(tx3); err != nil {
+		panic(err)
+	}
+
+	b, stage, receipts, err := flow.Pack(genesis.DevAccounts()[0].PrivateKey, block.MBlockType, 0)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := stage.Commit(); err != nil {
+		panic(err)
+	}
+	b.SetQC(&block.QuorumCert{QCHeight: 1, QCRound: 1, EpochID: 1, VoterBitArrayStr: "X_XXX", VoterMsgHash: meter.BytesToBytes32([]byte("hello")), VoterAggSig: []byte("voteraggr")})
+	escortQC := &block.QuorumCert{QCHeight: b.Number(), QCRound: b.QC.QCRound + 1, EpochID: b.QC.EpochID, VoterMsgHash: b.VotingHash()}
+	if _, err = c.AddBlock(b, escortQC, receipts); err != nil {
+		panic(err)
+	}
+	st, _ := state.New(b.Header().StateRoot(), kv)
+	sdb := statedb.New(st)
+
+	rt := runtime.New(seeker, st,
+		&xenv.BlockContext{Time: currentTs,
+			Number: meter.TeslaFork14_MainnetStartNum + 1,
+			Signer: tests.HolderAddr})
+
+	rt.EnforceTeslaFork8_LiquidStaking(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork10_Corrections(sdb, big.NewInt(0))
+	rt.EnforceTeslaFork12_Corrections(sdb, big.NewInt(0))
+	return &tests.TestEnv{Runtime: rt, State: st, BktCreateTS: 0, CurrentTS: currentTs, ChainTag: c.Tag()}
+}


### PR DESCRIPTION
## Summary

Based on the **deployed mainnet commit `89e2cc79`** (the `mainnet` branch was reset to it, with the prior HEAD preserved in `archived-master`). Introduces **TeslaFork14** to correct a state-flag bug.

**Fork13 flag was never set on mainnet.** The deployed `EnforceTeslaFork13_Corrections` contains a copy-paste bug — it writes `KeyEnforceTesla_Fork12_Correction` instead of `KeyEnforceTesla_Fork13_Correction`, so the Fork13 correction flag was never actually set. We **cannot** simply correct that function, because setting the flag retroactively at the already-passed Fork13 height (mainnet block 74838000) would change historical state and fork the chain. Instead, `EnforceTeslaFork14_Corrections` sets **both** the Fork13 and Fork14 flags at the future Fork14 block, where every node writes the same state.

### Fork activation blocks
- Mainnet: `95627400`
- Testnet: `99056000`

### Changes
- `meter/params.go`: add `KeyEnforceTesla_Fork14_Correction`
- `meter/chain_param.go`: add `TeslaFork14_*StartNum` and `IsTeslaFork14`
- `runtime/runtime.go`: add `EnforceTeslaFork14_Corrections` (sets both fork13 + fork14 flags), wired into `PrepareClause`
- `tests/fork14/`: flag-correction test

### Follow-up
The native-token value guard (`rejectInvalidNativeValue`), gated to activate after Fork14, is split into a separate follow-up PR stacked on this branch.

## Test plan
- [ ] CI: `go build`, `go vet`, and `tests/fork14` pass on Linux
- [ ] Confirm Fork14 mainnet/testnet activation blocks are correct for the deployment schedule
- [ ] Verify on a synced node that the Fork13 + Fork14 flags get set at the Fork14 block